### PR TITLE
Max image size

### DIFF
--- a/ant.properties
+++ b/ant.properties
@@ -14,7 +14,7 @@ class.version = 1.5
 
 #CSSEmbed properties
 cssembed.name = cssembed
-cssembed.version = 0.3.5
+cssembed.version = 0.3.6
 cssembed.jar = ${cssembed.name}-${cssembed.version}.jar
 cssembed.main = net.nczonline.web.cssembed.CSSEmbed
 

--- a/src/net/nczonline/web/cssembed/CSSEmbed.java
+++ b/src/net/nczonline/web/cssembed/CSSEmbed.java
@@ -64,6 +64,7 @@ public class CSSEmbed {
         CmdLineParser.Option mhtmlRootOpt = parser.addStringOption("mhtmlroot");
         CmdLineParser.Option skipMissingOpt = parser.addBooleanOption("skip-missing");
         CmdLineParser.Option uriLengthOpt = parser.addIntegerOption('u', "maxuri");
+        CmdLineParser.Option imageSizeOpt = parser.addIntegerOption('i', "image-size");
         
         try {
             
@@ -114,6 +115,8 @@ public class CSSEmbed {
             if (mhtml && mhtmlRoot == null){
                 throw new Exception("Must use --mhtmlroot when using --mhtml.");
             }
+            
+            //maximum length allowed for generated dataURI
             int maxurilength = 0;
             Integer uriOption = (Integer) parser.getOptionValue(uriLengthOpt);
             if (uriOption != null){
@@ -123,13 +126,23 @@ public class CSSEmbed {
                 }
             }
             
+            //maximum size allowed for image files
+            int maximagesize = 0;
+            Integer imageSizeOption = (Integer) parser.getOptionValue(imageSizeOpt);
+            if (imageSizeOption != null){
+                maximagesize = imageSizeOption.intValue();
+                if (maximagesize < 0){
+                    maximagesize = 0;
+                }
+            }
+            
             //are missing files ok?
             boolean skipMissingFiles = parser.getOptionValue(skipMissingOpt) != null;
             if(skipMissingFiles) {
                 options = options | CSSURLEmbedder.SKIP_MISSING_OPTION;
             }
             
-            CSSURLEmbedder embedder = new CSSURLEmbedder(in, options, verbose, maxurilength);            
+            CSSURLEmbedder embedder = new CSSURLEmbedder(in, options, verbose, maxurilength, maximagesize);            
             embedder.setMHTMLRoot(mhtmlRoot);
             
             //close in case writing to the same file
@@ -173,8 +186,6 @@ public class CSSEmbed {
                 out = new OutputStreamWriter(bytes, charset);
             }            
             
-            
-            
             //set verbose option
             embedder.embedImages(out, root);
             
@@ -191,6 +202,7 @@ public class CSSEmbed {
             if (out != null) {
                 try {
                     out.close();
+                    
                     bytes.writeTo(new FileOutputStream(outputFilename));
                 } catch (IOException e) {
                     System.err.println("[ERROR] " + e.getMessage());
@@ -219,6 +231,7 @@ public class CSSEmbed {
                 + "  --root <root>         Prepends <root> to all relative URLs.\n"
                 + "  --skip-missing        Don't throw an error for missing image files.\n"
                 + "  -u, --maxuri length   Maximum length of data URI to use.\n"
+                + "  -i, --image-size      Maximum image size (in bytes) to convert.\n"
                 + "  -o <file>             Place the output into <file>. Defaults to stdout."
         );
     }

--- a/src/net/nczonline/web/cssembed/CSSEmbed.java
+++ b/src/net/nczonline/web/cssembed/CSSEmbed.java
@@ -203,7 +203,9 @@ public class CSSEmbed {
                 try {
                     out.close();
                     
-                    bytes.writeTo(new FileOutputStream(outputFilename));
+                    if(bytes.size() > 0) {
+                        bytes.writeTo(new FileOutputStream(outputFilename));
+                    }
                 } catch (IOException e) {
                     System.err.println("[ERROR] " + e.getMessage());
                     if (verbose){

--- a/src/net/nczonline/web/cssembed/CSSEmbed.java
+++ b/src/net/nczonline/web/cssembed/CSSEmbed.java
@@ -105,7 +105,17 @@ public class CSSEmbed {
                 inputFilename = fileArgs[0];                     
                 in = new InputStreamReader(new FileInputStream(inputFilename), charset);            
             }
-            
+
+            //determine if there's a maximum URI length
+            int uriLength = CSSURLEmbedder.DEFAULT_MAX_URI_LENGTH;
+            Integer maxUriLength = (Integer) parser.getOptionValue(uriLengthOpt);
+            if (maxUriLength != null){
+                uriLength = maxUriLength.intValue();
+                if (uriLength < 0){
+                    uriLength = 0;
+                }
+            }
+
             //determine if MHTML mode is on
             boolean mhtml = parser.getOptionValue(mhtmlOpt) != null;
             if(mhtml){
@@ -224,17 +234,16 @@ public class CSSEmbed {
         System.out.println(
             "\nUsage: java -jar cssembed-x.y.z.jar [options] [input file]\n\n"
 
-                + "Global Options\n"
-                + "  -h, --help            Displays this information.\n"
-                + "  --charset <charset>   Character set of the input file.\n"
-                + "  --mhtml               Enable MHTML mode.\n"
-                + "  --mhtmlroot <root>    Use <root> as the MHTML root for the file.\n"                        
-                + "  -v, --verbose         Display informational messages and warnings.\n"
-                + "  --root <root>         Prepends <root> to all relative URLs.\n"
-                + "  --skip-missing        Don't throw an error for missing image files.\n"
-                + "  -u, --maxuri length   Maximum length of data URI to use.\n"
-                + "  -i, --image-size      Maximum image size (in bytes) to convert.\n"
-                + "  -o <file>             Place the output into <file>. Defaults to stdout."
-        );
+                        + "Global Options\n"
+                        + "  -h, --help            Displays this information.\n"
+                        + "  --charset <charset>   Character set of the input file.\n"
+                        + "  --mhtml               Enable MHTML mode.\n"
+                        + "  --mhtmlroot <root>    Use <root> as the MHTML root for the file.\n"                        
+                        + "  -v, --verbose         Display informational messages and warnings.\n"
+                        + "  --root <root>         Prepends <root> to all relative URLs.\n"
+                        + "  --skip-missing        Don't throw an error for missing image files.\n"
+                        + "  --max-uri-length len  Maximum length for a data URI. Defaults to 32768.\n"
+                        + "  -i, --image-size      Maximum image size (in bytes) to convert.\n"
+                        + "  -o <file>             Place the output into <file>. Defaults to stdout.");
     }
 }

--- a/src/net/nczonline/web/cssembed/CSSEmbed.java
+++ b/src/net/nczonline/web/cssembed/CSSEmbed.java
@@ -113,7 +113,7 @@ public class CSSEmbed {
                 throw new Exception("Must use --mhtmlroot when using --mhtml.");
             }
             int maxurilength = 0;
-            Integer uriOption = ((Integer) parser.getOptionValue(uriLengthOpt));
+            Integer uriOption = (Integer) parser.getOptionValue(uriLengthOpt);
             if (uriOption != null){
                 maxurilength = uriOption.intValue();
                 if (maxurilength < 0){

--- a/src/net/nczonline/web/cssembed/CSSEmbed.java
+++ b/src/net/nczonline/web/cssembed/CSSEmbed.java
@@ -115,6 +115,16 @@ public class CSSEmbed {
                     uriLength = 0;
                 }
             }
+            
+            //maximum size allowed for image files
+            int imageSize = 0;
+            Integer imageSizeOption = (Integer) parser.getOptionValue(imageSizeOpt);
+            if (imageSizeOption != null){
+                imageSize = imageSizeOption.intValue();
+                if (imageSize < 0){
+                    imageSize = 0;
+                }
+            }
 
             //determine if MHTML mode is on
             boolean mhtml = parser.getOptionValue(mhtmlOpt) != null;
@@ -124,26 +134,6 @@ public class CSSEmbed {
             String mhtmlRoot = (String) parser.getOptionValue(mhtmlRootOpt);
             if (mhtml && mhtmlRoot == null){
                 throw new Exception("Must use --mhtmlroot when using --mhtml.");
-            }
-            
-            //maximum length allowed for generated dataURI
-            int maxurilength = 0;
-            Integer uriOption = (Integer) parser.getOptionValue(uriLengthOpt);
-            if (uriOption != null){
-                maxurilength = uriOption.intValue();
-                if (maxurilength < 0){
-                    maxurilength = 0;
-                }
-            }
-            
-            //maximum size allowed for image files
-            int maximagesize = 0;
-            Integer imageSizeOption = (Integer) parser.getOptionValue(imageSizeOpt);
-            if (imageSizeOption != null){
-                maximagesize = imageSizeOption.intValue();
-                if (maximagesize < 0){
-                    maximagesize = 0;
-                }
             }
             
             //are missing files ok?

--- a/src/net/nczonline/web/cssembed/CSSEmbed.java
+++ b/src/net/nczonline/web/cssembed/CSSEmbed.java
@@ -60,6 +60,7 @@ public class CSSEmbed {
         CmdLineParser.Option outputFilenameOpt = parser.addStringOption('o', "output");
         CmdLineParser.Option mhtmlOpt = parser.addBooleanOption("mhtml");
         CmdLineParser.Option mhtmlRootOpt = parser.addStringOption("mhtmlroot");
+        CmdLineParser.Option uriLengthOpt = parser.addIntegerOption('u', "maxuri");
         
         
         try {
@@ -111,9 +112,17 @@ public class CSSEmbed {
             if (mhtml && mhtmlRoot == null){
                 throw new Exception("Must use --mhtmlroot when using --mhtml.");
             }
+            int maxurilength = 0;
+            Integer uriOption = ((Integer) parser.getOptionValue(uriLengthOpt));
+            if (uriOption != null){
+                maxurilength = uriOption.intValue();
+                if (maxurilength < 0){
+                    maxurilength = 0;
+                }
+            }
             
             
-            CSSURLEmbedder embedder = new CSSURLEmbedder(in, options, verbose);            
+            CSSURLEmbedder embedder = new CSSURLEmbedder(in, options, verbose, maxurilength);            
             embedder.setMHTMLRoot(mhtmlRoot);
             
             //close in case writing to the same file
@@ -198,6 +207,8 @@ public class CSSEmbed {
                         + "  --mhtmlroot <root>    Use <root> as the MHTML root for the file.\n"                        
                         + "  -v, --verbose         Display informational messages and warnings.\n"
                         + "  --root <root>         Prepends <root> to all relative URLs.\n"
-                        + "  -o <file>             Place the output into <file>. Defaults to stdout.");
+                        + "  -o <file>             Place the output into <file>. Defaults to stdout.\n"
+                        + "  -u, --maxuri length   Maximum length of data URI to use.\n"
+        );
     }
 }

--- a/src/net/nczonline/web/cssembed/CSSURLEmbedder.java
+++ b/src/net/nczonline/web/cssembed/CSSURLEmbedder.java
@@ -64,8 +64,8 @@ public class CSSURLEmbedder {
     private int options = 1;
     private String mhtmlRoot = "";
     private String outputFilename = "";
-    private int maxUriLength = DEFAULT_MAX_URI_LENGTH;  //IE8 only allows dataURIs up to 32KB
-    private int maximagesize;
+    private int maxUriLengthh = DEFAULT_MAX_URI_LENGTH;  //IE8 only allows dataURIs up to 32KB
+    private int maxImageSize;
     
     //--------------------------------------------------------------------------
     // Constructors
@@ -80,26 +80,23 @@ public class CSSURLEmbedder {
     }
     
     public CSSURLEmbedder(Reader in, boolean verbose) throws IOException {
-        this(in,1,verbose);
+        this(in, 1, verbose);
     }
     
     public CSSURLEmbedder(Reader in, int options, boolean verbose) throws IOException {
-        this(in,options,verbose,0,0);
+        this(in, options, verbose, 0);
     }
     
-    public CSSURLEmbedder(Reader in, int options, boolean verbose, int maxurilength, int maximagesize) throws IOException {
-        this.code = readCode(in);
-        this.verbose = verbose;
-        this.options = options;
-        this.maxurilength = maxurilength;
-        this.maximagesize = maximagesize;
+    public CSSURLEmbedder(Reader in, int options, boolean verbose, int maxUriLengthh) throws IOException {
+        this(in, options, verbose, maxUriLengthh, 0);
     }
-
-    public CSSURLEmbedder(Reader in, int options, boolean verbose, int maxUriLength) throws IOException {
+    
+    public CSSURLEmbedder(Reader in, int options, boolean verbose, int maxUriLengthh, int maxImageSize) throws IOException {
         this.code = readCode(in);
         this.verbose = verbose;
         this.options = options;
-        this.maxUriLength = maxUriLength;
+        this.maxUriLengthh = maxUriLengthh;
+        this.maxImageSize = maxImageSize;
     }
 
     //--------------------------------------------------------------------------
@@ -166,8 +163,6 @@ public class CSSURLEmbedder {
         StringBuilder builder = new StringBuilder();
         StringBuilder mhtmlHeader = new StringBuilder();
         HashMap<String,Integer> foundMedia = new HashMap<String,Integer>();
-        int conversions = 0;
-        
         String line;
         int lineNum = 1;        
         int conversions = 0;
@@ -240,14 +235,14 @@ public class CSSURLEmbedder {
                     if (uriString.startsWith("data:")){
 
                         
-                        if (maxUriLength > 0 && uriString.length() > maxUriLength) {
+                        if (maxUriLengthh > 0 && uriString.length() > maxUriLengthh) {
                             if (verbose){
-                                System.err.println("[WARNING] File " + newUrl + " creates a data URI larger than " + maxUriLength + " bytes. Skipping.");
+                                System.err.println("[WARNING] File " + newUrl + " creates a data URI larger than " + maxUriLengthh + " bytes. Skipping.");
                             }      
                             builder.append(url);
-                        } else if (maxurilength > 0 && uriString.length() > maxurilength){
+                        } else if (maxUriLengthh > 0 && uriString.length() > maxUriLengthh){
                             if (verbose) {
-                                System.err.println("[INFO] File " + newUrl + " creates a data URI longer than " + maxurilength + " characters. Skipping.");
+                                System.err.println("[INFO] File " + newUrl + " creates a data URI longer than " + maxUriLengthh + " characters. Skipping.");
                             }
                             builder.append(url);
                         } else {
@@ -358,9 +353,9 @@ public class CSSURLEmbedder {
                     }
                     
                     //check file size if we've been asked to
-                    if(this.maximagesize > 0 && file.length() > this.maximagesize) {
+                    if(this.maxImageSize > 0 && file.length() > this.maxImageSize) {
                         if(verbose) {
-                            System.err.println("[INFO] File " + originalUrl + " is larger than " + this.maximagesize + " bytes. Skipping.");
+                            System.err.println("[INFO] File " + originalUrl + " is larger than " + this.maxImageSize + " bytes. Skipping.");
                         }
                         
                         writer.write(originalUrl);

--- a/src/net/nczonline/web/cssembed/CSSURLEmbedder.java
+++ b/src/net/nczonline/web/cssembed/CSSURLEmbedder.java
@@ -60,6 +60,7 @@ public class CSSURLEmbedder {
     private int options = 1;
     private String mhtmlRoot = "";
     private String outputFilename = "";
+    private int maxurilength;
     
     //--------------------------------------------------------------------------
     // Constructors
@@ -78,9 +79,14 @@ public class CSSURLEmbedder {
     }
     
     public CSSURLEmbedder(Reader in, int options, boolean verbose) throws IOException {
+        this(in,1,verbose,0);
+    }
+    
+    public CSSURLEmbedder(Reader in, int options, boolean verbose, int maxurilength) throws IOException {
         this.code = readCode(in);
         this.verbose = verbose;
         this.options = options;
+        this.maxurilength = maxurilength;
     }
     
     //--------------------------------------------------------------------------
@@ -221,6 +227,11 @@ public class CSSURLEmbedder {
                         //IE8 only allows dataURIs up to 32KB
                         if (uriString.length() > 32768){
                             System.err.println("[WARNING] File " + newUrl + " creates a data URI larger than 32KB. IE8 can't display data URI images this large. Skipping.");
+                            builder.append(url);
+                        } else if (maxurilength > 0 && uriString.length() > maxurilength){
+                            if (verbose) {
+                                System.err.println("[INFO] File " + newUrl + " creates a data URI longer than " + maxurilength + " characters. Skipping.");
+                            }
                             builder.append(url);
                         } else {
 

--- a/src/net/nczonline/web/cssembed/CSSURLEmbedder.java
+++ b/src/net/nczonline/web/cssembed/CSSURLEmbedder.java
@@ -64,7 +64,7 @@ public class CSSURLEmbedder {
     private int options = 1;
     private String mhtmlRoot = "";
     private String outputFilename = "";
-    private int maxUriLengthh = DEFAULT_MAX_URI_LENGTH;  //IE8 only allows dataURIs up to 32KB
+    private int maxUriLength = DEFAULT_MAX_URI_LENGTH;  //IE8 only allows dataURIs up to 32KB
     private int maxImageSize;
     
     //--------------------------------------------------------------------------
@@ -87,15 +87,15 @@ public class CSSURLEmbedder {
         this(in, options, verbose, 0);
     }
     
-    public CSSURLEmbedder(Reader in, int options, boolean verbose, int maxUriLengthh) throws IOException {
-        this(in, options, verbose, maxUriLengthh, 0);
+    public CSSURLEmbedder(Reader in, int options, boolean verbose, int maxUriLength) throws IOException {
+        this(in, options, verbose, maxUriLength, 0);
     }
     
-    public CSSURLEmbedder(Reader in, int options, boolean verbose, int maxUriLengthh, int maxImageSize) throws IOException {
+    public CSSURLEmbedder(Reader in, int options, boolean verbose, int maxUriLength, int maxImageSize) throws IOException {
         this.code = readCode(in);
         this.verbose = verbose;
         this.options = options;
-        this.maxUriLengthh = maxUriLengthh;
+        this.maxUriLength = maxUriLength;
         this.maxImageSize = maxImageSize;
     }
 
@@ -235,14 +235,14 @@ public class CSSURLEmbedder {
                     if (uriString.startsWith("data:")){
 
                         
-                        if (maxUriLengthh > 0 && uriString.length() > maxUriLengthh) {
+                        if (maxUriLength > 0 && uriString.length() > maxUriLength) {
                             if (verbose){
-                                System.err.println("[WARNING] File " + newUrl + " creates a data URI larger than " + maxUriLengthh + " bytes. Skipping.");
+                                System.err.println("[WARNING] File " + newUrl + " creates a data URI larger than " + maxUriLength + " bytes. Skipping.");
                             }      
                             builder.append(url);
-                        } else if (maxUriLengthh > 0 && uriString.length() > maxUriLengthh){
+                        } else if (maxUriLength > 0 && uriString.length() > maxUriLength){
                             if (verbose) {
-                                System.err.println("[INFO] File " + newUrl + " creates a data URI longer than " + maxUriLengthh + " characters. Skipping.");
+                                System.err.println("[INFO] File " + newUrl + " creates a data URI longer than " + maxUriLength + " characters. Skipping.");
                             }
                             builder.append(url);
                         } else {

--- a/src/net/nczonline/web/cssembed/CSSURLEmbedder.java
+++ b/src/net/nczonline/web/cssembed/CSSURLEmbedder.java
@@ -81,7 +81,7 @@ public class CSSURLEmbedder {
     }
     
     public CSSURLEmbedder(Reader in, int options, boolean verbose) throws IOException {
-        this(in,1,verbose,0);
+        this(in,options,verbose,0);
     }
     
     public CSSURLEmbedder(Reader in, int options, boolean verbose, int maxurilength) throws IOException {

--- a/src/net/nczonline/web/cssembed/CSSURLEmbedder.java
+++ b/src/net/nczonline/web/cssembed/CSSURLEmbedder.java
@@ -63,6 +63,7 @@ public class CSSURLEmbedder {
     private String mhtmlRoot = "";
     private String outputFilename = "";
     private int maxurilength;
+    private int maximagesize;
     
     //--------------------------------------------------------------------------
     // Constructors
@@ -81,14 +82,15 @@ public class CSSURLEmbedder {
     }
     
     public CSSURLEmbedder(Reader in, int options, boolean verbose) throws IOException {
-        this(in,options,verbose,0);
+        this(in,options,verbose,0,0);
     }
     
-    public CSSURLEmbedder(Reader in, int options, boolean verbose, int maxurilength) throws IOException {
+    public CSSURLEmbedder(Reader in, int options, boolean verbose, int maxurilength, int maximagesize) throws IOException {
         this.code = readCode(in);
         this.verbose = verbose;
         this.options = options;
         this.maxurilength = maxurilength;
+        this.maximagesize = maximagesize;
     }
     
     //--------------------------------------------------------------------------
@@ -338,9 +340,19 @@ public class CSSURLEmbedder {
                     
                     if (verbose && !file.isFile()){
                         System.err.println("[INFO] Could not find file '" + file.getCanonicalPath() + "'.");
-                    }                 
+                    }
                     
-                    DataURIGenerator.generate(new File(url), writer); 
+                    //check file size if we've been asked to
+                    if(this.maximagesize > 0 && file.length() > this.maximagesize) {
+                        if(verbose) {
+                            System.err.println("[INFO] File " + originalUrl + " is larger than " + this.maximagesize + " bytes. Skipping.");
+                        }
+                        
+                        writer.write(originalUrl);
+                        
+                    } else {
+                        DataURIGenerator.generate(new File(url), writer); 
+                    }
                 }
 
                 if (verbose){

--- a/src/net/nczonline/web/cssembed/CSSURLEmbedder.java
+++ b/src/net/nczonline/web/cssembed/CSSURLEmbedder.java
@@ -153,6 +153,7 @@ public class CSSURLEmbedder {
         StringBuilder builder = new StringBuilder();
         StringBuilder mhtmlHeader = new StringBuilder();
         HashMap<String,Integer> foundMedia = new HashMap<String,Integer>();
+        int conversions = 0;
         
         String line;
         int lineNum = 1;        
@@ -257,6 +258,7 @@ public class CSSURLEmbedder {
                                 builder.append(getMHTMLPath());
                                 builder.append("!");
                                 builder.append(entryName);
+                                conversions++;
                             } else if (hasOption(DATAURI_OPTION)){
                                 builder.append(uriString);
                             }
@@ -282,7 +284,7 @@ public class CSSURLEmbedder {
         }
         reader.close();
 
-        if (hasOption(MHTML_OPTION)){
+        if (hasOption(MHTML_OPTION) && conversions > 0){
 
             //Add one more boundary to fix IE/Vista issue
             mhtmlHeader.append("\n--");

--- a/tests/net/nczonline/web/cssembed/CSSURLEmbedderTest.java
+++ b/tests/net/nczonline/web/cssembed/CSSURLEmbedderTest.java
@@ -141,6 +141,32 @@ public class CSSURLEmbedderTest {
     }
     
     @Test
+    public void testAbsoluteLocalFileUnderMaxSize() throws IOException {
+        String filename = CSSURLEmbedderTest.class.getResource("folder.png").getPath().replace("%20", " ");
+        String code = "background: url(folder.png);";
+        
+        StringWriter writer = new StringWriter();
+        embedder = new CSSURLEmbedder(new StringReader(code), CSSURLEmbedder.DATAURI_OPTION, true, 1000);
+        embedder.embedImages(writer, filename.substring(0, filename.lastIndexOf("/")+1));
+        
+        String result = writer.toString();
+        assertEquals("background: url(" + folderDataURI + ");", result);
+    }
+    
+    @Test
+    public void testAbsoluteLocalFileOverMaxSize() throws IOException {
+        String filename = CSSURLEmbedderTest.class.getResource("folder.png").getPath().replace("%20", " ");
+        String code = "background: url(folder.png);";
+        
+        StringWriter writer = new StringWriter();
+        embedder = new CSSURLEmbedder(new StringReader(code), CSSURLEmbedder.DATAURI_OPTION, true, 200);
+        embedder.embedImages(writer, filename.substring(0, filename.lastIndexOf("/")+1));
+        
+        String result = writer.toString();
+        assertEquals(code, result);
+    }
+    
+    @Test
     public void testReadFromAndWriteToSameFile() throws IOException {
         String filename = CSSURLEmbedderTest.class.getResource("samefiletest.css").getPath().replace("%20", " ");
         File file = new File(filename);
@@ -176,9 +202,6 @@ public class CSSURLEmbedderTest {
 
 
         String result = writer.toString();
-        assertEquals("/*\nContent-Type: multipart/related; boundary=\"" + CSSURLEmbedder.MHTML_SEPARATOR +
-                "\"\n\n" +
-                "\n--" + CSSURLEmbedder.MHTML_SEPARATOR + "--\n" +
-                "*/\nbackground: url(folder.txt);", result);
+        assertEquals("background: url(folder.txt);", result);
     }
 }

--- a/tests/net/nczonline/web/cssembed/CSSURLEmbedderTest.java
+++ b/tests/net/nczonline/web/cssembed/CSSURLEmbedderTest.java
@@ -141,38 +141,12 @@ public class CSSURLEmbedderTest {
     }
 
     @Test
-    public void testAbsoluteLocalFileUnderMaxSize() throws IOException {
-        String filename = CSSURLEmbedderTest.class.getResource("folder.png").getPath().replace("%20", " ");
-        String code = "background: url(folder.png);";
-
-        StringWriter writer = new StringWriter();
-        embedder = new CSSURLEmbedder(new StringReader(code), CSSURLEmbedder.DATAURI_OPTION, true, 1000);
-        embedder.embedImages(writer, filename.substring(0, filename.lastIndexOf("/")+1));
-
-        String result = writer.toString();
-        assertEquals("background: url(" + folderDataURI + ");", result);
-    }
-
-    @Test
-    public void testAbsoluteLocalFileOverMaxSize() throws IOException {
-        String filename = CSSURLEmbedderTest.class.getResource("folder.png").getPath().replace("%20", " ");
-        String code = "background: url(folder.png);";
-
-        StringWriter writer = new StringWriter();
-        embedder = new CSSURLEmbedder(new StringReader(code), CSSURLEmbedder.DATAURI_OPTION, true, 200);
-        embedder.embedImages(writer, filename.substring(0, filename.lastIndexOf("/")+1));
-
-        String result = writer.toString();
-        assertEquals(code, result);
-    }
-    
-    @Test
     public void testAbsoluteLocalFileUnderMaxLength() throws IOException {
         String filename = CSSURLEmbedderTest.class.getResource("folder.png").getPath().replace("%20", " ");
         String code = "background: url(folder.png);";
         
         StringWriter writer = new StringWriter();
-        embedder = new CSSURLEmbedder(new StringReader(code), CSSURLEmbedder.DATAURI_OPTION, true, 1000, 0);
+        embedder = new CSSURLEmbedder(new StringReader(code), CSSURLEmbedder.DATAURI_OPTION, true, 1000);
         embedder.embedImages(writer, filename.substring(0, filename.lastIndexOf("/")+1));
         
         String result = writer.toString();
@@ -185,7 +159,7 @@ public class CSSURLEmbedderTest {
         String code = "background: url(folder.png);";
         
         StringWriter writer = new StringWriter();
-        embedder = new CSSURLEmbedder(new StringReader(code), CSSURLEmbedder.DATAURI_OPTION, true, 200, 0);
+        embedder = new CSSURLEmbedder(new StringReader(code), CSSURLEmbedder.DATAURI_OPTION, true, 200);
         embedder.embedImages(writer, filename.substring(0, filename.lastIndexOf("/")+1));
         
         String result = writer.toString();

--- a/tests/net/nczonline/web/cssembed/CSSURLEmbedderTest.java
+++ b/tests/net/nczonline/web/cssembed/CSSURLEmbedderTest.java
@@ -141,12 +141,12 @@ public class CSSURLEmbedderTest {
     }
     
     @Test
-    public void testAbsoluteLocalFileUnderMaxSize() throws IOException {
+    public void testAbsoluteLocalFileUnderMaxLength() throws IOException {
         String filename = CSSURLEmbedderTest.class.getResource("folder.png").getPath().replace("%20", " ");
         String code = "background: url(folder.png);";
         
         StringWriter writer = new StringWriter();
-        embedder = new CSSURLEmbedder(new StringReader(code), CSSURLEmbedder.DATAURI_OPTION, true, 1000);
+        embedder = new CSSURLEmbedder(new StringReader(code), CSSURLEmbedder.DATAURI_OPTION, true, 1000, 0);
         embedder.embedImages(writer, filename.substring(0, filename.lastIndexOf("/")+1));
         
         String result = writer.toString();
@@ -154,12 +154,38 @@ public class CSSURLEmbedderTest {
     }
     
     @Test
-    public void testAbsoluteLocalFileOverMaxSize() throws IOException {
+    public void testAbsoluteLocalFileOverMaxLength() throws IOException {
         String filename = CSSURLEmbedderTest.class.getResource("folder.png").getPath().replace("%20", " ");
         String code = "background: url(folder.png);";
         
         StringWriter writer = new StringWriter();
-        embedder = new CSSURLEmbedder(new StringReader(code), CSSURLEmbedder.DATAURI_OPTION, true, 200);
+        embedder = new CSSURLEmbedder(new StringReader(code), CSSURLEmbedder.DATAURI_OPTION, true, 200, 0);
+        embedder.embedImages(writer, filename.substring(0, filename.lastIndexOf("/")+1));
+        
+        String result = writer.toString();
+        assertEquals(code, result);
+    }
+    
+    @Test
+    public void testAbsoluteLocalFileUnderMaxImageSize() throws IOException {
+        String filename = CSSURLEmbedderTest.class.getResource("folder.png").getPath().replace("%20", " ");
+        String code = "background: url(folder.png);";
+        
+        StringWriter writer = new StringWriter();
+        embedder = new CSSURLEmbedder(new StringReader(code), CSSURLEmbedder.DATAURI_OPTION, true, 0, 300);
+        embedder.embedImages(writer, filename.substring(0, filename.lastIndexOf("/")+1));
+        
+        String result = writer.toString();
+        assertEquals("background: url(" + folderDataURI + ");", result);
+    }
+    
+    @Test
+    public void testAbsoluteLocalFileOverMaxImageSize() throws IOException {
+        String filename = CSSURLEmbedderTest.class.getResource("folder.png").getPath().replace("%20", " ");
+        String code = "background: url(folder.png);";
+        
+        StringWriter writer = new StringWriter();
+        embedder = new CSSURLEmbedder(new StringReader(code), CSSURLEmbedder.DATAURI_OPTION, true, 0, 200);
         embedder.embedImages(writer, filename.substring(0, filename.lastIndexOf("/")+1));
         
         String result = writer.toString();

--- a/tests/net/nczonline/web/cssembed/CSSURLEmbedderTest.java
+++ b/tests/net/nczonline/web/cssembed/CSSURLEmbedderTest.java
@@ -139,6 +139,32 @@ public class CSSURLEmbedderTest {
         String result = writer.toString();
         assertEquals(code, result);
     }
+
+    @Test
+    public void testAbsoluteLocalFileUnderMaxSize() throws IOException {
+        String filename = CSSURLEmbedderTest.class.getResource("folder.png").getPath().replace("%20", " ");
+        String code = "background: url(folder.png);";
+
+        StringWriter writer = new StringWriter();
+        embedder = new CSSURLEmbedder(new StringReader(code), CSSURLEmbedder.DATAURI_OPTION, true, 1000);
+        embedder.embedImages(writer, filename.substring(0, filename.lastIndexOf("/")+1));
+
+        String result = writer.toString();
+        assertEquals("background: url(" + folderDataURI + ");", result);
+    }
+
+    @Test
+    public void testAbsoluteLocalFileOverMaxSize() throws IOException {
+        String filename = CSSURLEmbedderTest.class.getResource("folder.png").getPath().replace("%20", " ");
+        String code = "background: url(folder.png);";
+
+        StringWriter writer = new StringWriter();
+        embedder = new CSSURLEmbedder(new StringReader(code), CSSURLEmbedder.DATAURI_OPTION, true, 200);
+        embedder.embedImages(writer, filename.substring(0, filename.lastIndexOf("/")+1));
+
+        String result = writer.toString();
+        assertEquals(code, result);
+    }
     
     @Test
     public void testAbsoluteLocalFileUnderMaxLength() throws IOException {


### PR DESCRIPTION
Added a --max-image-size option, which lets you specify that images w/ a filesize greater than that number of bytes will not be converted to a DataURI.

This is sort of messy, still getting my feet wet in terms of git branching/merging. Hopefully it's not a terrible merge for you.
