### PR TITLE
Missing File notification should honor verbose setting

### DIFF
--- a/src/net/nczonline/web/cssembed/CSSURLEmbedder.java
+++ b/src/net/nczonline/web/cssembed/CSSURLEmbedder.java
@@ -368,8 +368,10 @@ public class CSSURLEmbedder {
                     System.err.println("[INFO] Generated data URI for '" + url + "'.");
                 }
             } catch (FileNotFoundException e){ 
-                if (hasOption(SKIP_MISSING_OPTION)){
-                    System.err.println("[INFO] Could not find file. " + e.getMessage() + " Skipping.");
+                if(hasOption(SKIP_MISSING_OPTION)) {
+                    if (verbose){
+                        System.err.println("[INFO] Could not find file. " + e.getMessage() + " Skipping.");
+                    }
                 
                     writer.write(originalUrl);
                 } else {


### PR DESCRIPTION
Previously it would complain every time, so I've wrapped it in a if(verbose){} block to make sure it doesn't complain unnecessarily.
