### PR TITLE
Closing FileOutputStream

### DIFF
--- a/src/net/nczonline/web/cssembed/CSSEmbedTask.java
+++ b/src/net/nczonline/web/cssembed/CSSEmbedTask.java
@@ -230,11 +230,14 @@ public class CSSEmbedTask extends Task {
         out.close();
         
         if(bytes.size() > 0) {
+            FileOutputStream fos = new FileOutputStream(output);
+            
             if(verbose) {
                 log("[INFO] Writing to file: " + output);
             }
             
-            bytes.writeTo(new FileOutputStream(output));
+            bytes.writeTo(fos);
+            fos.close();
         }
     }
 }


### PR DESCRIPTION
Prevents Ant from being unable to move files immediately after they have been written.
