### PR TITLE
Issues #17 and #34, proposed resolutions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/
 nbproject/
 tmp/
+.DS_Store

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+January 5, 2012 - v0.4.6
+* Add option for MHTML output file separate from CSS output file. (jbarker)
+* Fixed bug where MHTML content was not rendered by IE6 & IE7.
+
 November 22, 2011 - v0.4.5
 * Add option to skip some images using /*CSSEmbed:SKIP*/ after the declaration.
 

--- a/ant.properties
+++ b/ant.properties
@@ -15,7 +15,7 @@ class.version = 1.5
 
 #CSSEmbed properties
 cssembed.name = cssembed
-cssembed.version = 0.4.6-SNAPSHOT
+cssembed.version = 0.4.6
 cssembed.jar = ${cssembed.name}-${cssembed.version}.jar
 cssembed.main = net.nczonline.web.cssembed.CSSEmbed
 

--- a/ant.properties
+++ b/ant.properties
@@ -15,7 +15,7 @@ class.version = 1.5
 
 #CSSEmbed properties
 cssembed.name = cssembed
-cssembed.version = 0.4.5
+cssembed.version = 0.4.6-SNAPSHOT
 cssembed.jar = ${cssembed.name}-${cssembed.version}.jar
 cssembed.main = net.nczonline.web.cssembed.CSSEmbed
 

--- a/src/net/nczonline/web/cssembed/CSSEmbed.java
+++ b/src/net/nczonline/web/cssembed/CSSEmbed.java
@@ -46,9 +46,9 @@ public class CSSEmbed {
         //default settings
         boolean verbose = false;
         String charset = null;
-        String outputFilename = null;
-        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
-        Writer out = null;
+        String cssOutputFilename = null;
+        ByteArrayOutputStream cssBytes = new ByteArrayOutputStream();
+        Writer cssOut = null;
         Reader in = null;
         String root;
         int options = CSSURLEmbedder.DATAURI_OPTION;
@@ -59,7 +59,7 @@ public class CSSEmbed {
         CmdLineParser.Option helpOpt = parser.addBooleanOption('h', "help");
         CmdLineParser.Option charsetOpt = parser.addStringOption("charset");
         CmdLineParser.Option rootOpt = parser.addStringOption("root");
-        CmdLineParser.Option outputFilenameOpt = parser.addStringOption('o', "output");
+        CmdLineParser.Option cssOutputFilenameOpt = parser.addStringOption('o', "output");
         CmdLineParser.Option mhtmlOpt = parser.addBooleanOption("mhtml");
         CmdLineParser.Option mhtmlRootOpt = parser.addStringOption("mhtmlroot");
         CmdLineParser.Option skipMissingOpt = parser.addBooleanOption("skip-missing");
@@ -169,25 +169,25 @@ public class CSSEmbed {
                 System.err.println("[INFO] Using '" + root + "' as root for relative file paths.");
             }
 
-            //get output filename
-            outputFilename = (String) parser.getOptionValue(outputFilenameOpt);
-            if (outputFilename == null) {
+            //get CSS output filename
+            cssOutputFilename = (String) parser.getOptionValue(cssOutputFilenameOpt);
+            if (cssOutputFilename == null) {
                 if (verbose){
-                    System.err.println("[INFO] No output file specified, defaulting to stdout.");
+                    System.err.println("[INFO] No CSS output file specified, defaulting to stdout.");
                 }
 
-                out = new OutputStreamWriter(System.out);
+                cssOut = new OutputStreamWriter(System.out);
             } else {
-                File outputFile = new File(outputFilename);
+                File cssOutputFile = new File(cssOutputFilename);
                 if (verbose){
-                    System.err.println("[INFO] Output file is '" + outputFile.getAbsolutePath() + "'");
+                    System.err.println("[INFO] CSS output file is '" + cssOutputFile.getAbsolutePath() + "'");
                 }
-                embedder.setFilename(outputFile.getName());
-                out = new OutputStreamWriter(bytes, charset);
+                embedder.setFilename(cssOutputFile.getName());
+                cssOut = new OutputStreamWriter(cssBytes, charset);
             }
 
             //set verbose option
-            embedder.embedImages(out, root);
+            embedder.embedImages(cssOut, root);
 
         } catch (CmdLineParser.OptionException e) {
             usage();
@@ -199,12 +199,12 @@ public class CSSEmbed {
             }
             System.exit(1);
         } finally {
-            if (out != null) {
+            if (cssOut != null) {
                 try {
-                    out.close();
+                    cssOut.close();
 
-                    if(bytes.size() > 0) {
-                        bytes.writeTo(new FileOutputStream(outputFilename));
+                    if(cssBytes.size() > 0) {
+                        cssBytes.writeTo(new FileOutputStream(cssOutputFilename));
                     }
                 } catch (IOException e) {
                     System.err.println("[ERROR] " + e.getMessage());
@@ -234,6 +234,6 @@ public class CSSEmbed {
                         + "  --skip-missing        Don't throw an error for missing image files.\n"
                         + "  --max-uri-length len  Maximum length for a data URI. Defaults to 32768.\n"
                         + "  --max-image-size size Maximum image size (in bytes) to convert.\n"
-                        + "  -o <file>             Place the output into <file>. Defaults to stdout.");
+                        + "  -o <file>             Place the CSS output into <file>. Defaults to stdout.");
     }
 }

--- a/src/net/nczonline/web/cssembed/CSSEmbed.java
+++ b/src/net/nczonline/web/cssembed/CSSEmbed.java
@@ -1,17 +1,17 @@
 /*
  * Copyright (c) 2009 Nicholas C. Zakas. All rights reserved.
  * http://www.nczonline.net/
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -35,14 +35,14 @@ import java.io.Writer;
 import java.nio.charset.Charset;
 
 
-public class CSSEmbed {    
+public class CSSEmbed {
 
-    
+
     /**
      * @param args the command line arguments
      */
     public static void main(String[] args) {
-        
+
         //default settings
         boolean verbose = false;
         String charset = null;
@@ -52,7 +52,7 @@ public class CSSEmbed {
         Reader in = null;
         String root;
         int options = CSSURLEmbedder.DATAURI_OPTION;
-        
+
         //initialize command line parser
         CmdLineParser parser = new CmdLineParser();
         CmdLineParser.Option verboseOpt = parser.addBooleanOption('v', "verbose");
@@ -65,9 +65,9 @@ public class CSSEmbed {
         CmdLineParser.Option skipMissingOpt = parser.addBooleanOption("skip-missing");
         CmdLineParser.Option uriLengthOpt = parser.addIntegerOption("max-uri-length");
         CmdLineParser.Option imageSizeOpt = parser.addIntegerOption("max-image-size");
-        
+
         try {
-            
+
             //parse the arguments
             parser.parse(args);
 
@@ -76,11 +76,11 @@ public class CSSEmbed {
             if (help != null && help.booleanValue()) {
                 usage();
                 System.exit(0);
-            } 
-            
+            }
+
             //determine boolean options
             verbose = parser.getOptionValue(verboseOpt) != null;
-            
+
             //check for charset
             charset = (String) parser.getOptionValue(charsetOpt);
             if (charset == null || !Charset.isSupported(charset)) {
@@ -92,18 +92,18 @@ public class CSSEmbed {
                     System.err.println("\n[INFO] Using charset " + charset);
                 }
             }
-          
+
             //get the file arguments
             String[] fileArgs = parser.getRemainingArgs();
             String inputFilename = null;
-            
+
             //if no file is given, use stdin
             if (fileArgs.length == 0){
                 in = new InputStreamReader(System.in, charset);
             } else {
                 //only the first filename is used
-                inputFilename = fileArgs[0];                     
-                in = new InputStreamReader(new FileInputStream(inputFilename), charset);            
+                inputFilename = fileArgs[0];
+                in = new InputStreamReader(new FileInputStream(inputFilename), charset);
             }
 
             //determine if there's a maximum URI length
@@ -115,7 +115,7 @@ public class CSSEmbed {
                     uriLength = 0;
                 }
             }
-            
+
             //maximum size allowed for image files
             int imageSize = 0;
             Integer imageSizeOption = (Integer) parser.getOptionValue(imageSizeOpt);
@@ -135,47 +135,47 @@ public class CSSEmbed {
             if (mhtml && mhtmlRoot == null){
                 throw new Exception("Must use --mhtmlroot when using --mhtml.");
             }
-            
+
             //are missing files ok?
             boolean skipMissingFiles = parser.getOptionValue(skipMissingOpt) != null;
             if(skipMissingFiles) {
                 options = options | CSSURLEmbedder.SKIP_MISSING_OPTION;
             }
-            
-            CSSURLEmbedder embedder = new CSSURLEmbedder(in, options, verbose, uriLength, imageSize);            
+
+            CSSURLEmbedder embedder = new CSSURLEmbedder(in, options, verbose, uriLength, imageSize);
             embedder.setMHTMLRoot(mhtmlRoot);
-            
+
             //close in case writing to the same file
             in.close(); in = null;
-            
+
             //get root for relative URLs
             root = (String) parser.getOptionValue(rootOpt);
             if(root == null){
-            
+
                 if (inputFilename != null) {
                     //no root specified, so get from input file
                     root = (new File(inputFilename)).getCanonicalPath();
-                    root = root.substring(0, root.lastIndexOf(File.separator));                
+                    root = root.substring(0, root.lastIndexOf(File.separator));
                 } else {
                     throw new Exception("Must use --root when not specifying a filename.");
                 }
             }
-            
+
             if (!root.endsWith(File.separator)){
                 root += File.separator;
             }
-            
+
             if (verbose){
                 System.err.println("[INFO] Using '" + root + "' as root for relative file paths.");
             }
-                                  
+
             //get output filename
-            outputFilename = (String) parser.getOptionValue(outputFilenameOpt);            
+            outputFilename = (String) parser.getOptionValue(outputFilenameOpt);
             if (outputFilename == null) {
                 if (verbose){
                     System.err.println("[INFO] No output file specified, defaulting to stdout.");
-                }                
-                
+                }
+
                 out = new OutputStreamWriter(System.out);
             } else {
                 File outputFile = new File(outputFilename);
@@ -184,15 +184,15 @@ public class CSSEmbed {
                 }
                 embedder.setFilename(outputFile.getName());
                 out = new OutputStreamWriter(bytes, charset);
-            }            
-            
+            }
+
             //set verbose option
             embedder.embedImages(out, root);
-            
+
         } catch (CmdLineParser.OptionException e) {
             usage();
-            System.exit(1);            
-        } catch (Exception e) { 
+            System.exit(1);
+        } catch (Exception e) {
             System.err.println("[ERROR] " + e.getMessage());
             if (verbose){
                 e.printStackTrace();
@@ -202,7 +202,7 @@ public class CSSEmbed {
             if (out != null) {
                 try {
                     out.close();
-                    
+
                     if(bytes.size() > 0) {
                         bytes.writeTo(new FileOutputStream(outputFilename));
                     }
@@ -212,11 +212,11 @@ public class CSSEmbed {
                         e.printStackTrace();
                     }
                 }
-            }            
+            }
         }
-        
+
     }
-    
+
     /**
      * Outputs help information to the console.
      */
@@ -228,7 +228,7 @@ public class CSSEmbed {
                         + "  -h, --help            Displays this information.\n"
                         + "  --charset <charset>   Character set of the input file.\n"
                         + "  --mhtml               Enable MHTML mode.\n"
-                        + "  --mhtmlroot <root>    Use <root> as the MHTML root for the file.\n"                        
+                        + "  --mhtmlroot <root>    Use <root> as the MHTML root for the file.\n"
                         + "  -v, --verbose         Display informational messages and warnings.\n"
                         + "  --root <root>         Prepends <root> to all relative URLs.\n"
                         + "  --skip-missing        Don't throw an error for missing image files.\n"

--- a/src/net/nczonline/web/cssembed/CSSEmbedTask.java
+++ b/src/net/nczonline/web/cssembed/CSSEmbedTask.java
@@ -1,17 +1,17 @@
 /*
  * Copyright (c) 2009 Nicholas C. Zakas. All rights reserved.
  * http://www.nczonline.net/
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -41,7 +41,7 @@ import java.util.Iterator;
 
 //Define a custom Ant Task that calls into the CSS Embedder
 public class CSSEmbedTask extends Task {
-    
+
     //attribute options
     private String charset = "UTF-8";
     private String root;
@@ -53,59 +53,59 @@ public class CSSEmbedTask extends Task {
     private int maxImageSize = 0;
     private File srcFile;
     private File destFile;
-    
+
     //support nested resource collections & mappers
     private Mapper mapperElement = null;
     private Vector rcs = new Vector();
-    
+
     //Simple Setters
     public void setCharset(String charset) {
         this.charset = charset;
     }
-    
+
     public void setRoot(String root) {
         this.root = root;
     }
-    
+
     public void setMhtml(boolean mhtml) {
         this.mhtml = mhtml;
     }
-    
+
     public void setMhtmlRoot(String mhtmlRoot) {
         this.mhtmlRoot = mhtmlRoot;
     }
-    
+
     public void setSkipMissing(boolean skipMissing) {
         this.skipMissing = skipMissing;
     }
-    
+
     public void setVerbose(boolean verbose) {
         this.verbose = verbose;
     }
-    
+
     public void setMaxUriLength(int maxUriLength) {
         this.maxUriLength = maxUriLength;
     }
-    
+
     public void setMaxImageSize(int maxImageSize) {
         this.maxImageSize = maxImageSize;
     }
-    
+
     public void setSrcFile(File srcFile) {
         this.srcFile = srcFile;
     }
-    
+
     public void setDestFile(File destFile) {
         this.destFile = destFile;
     }
-    
+
     //More complicated setters for nested elements...
-    
+
     //add a collection of resources to copy
     public void add(ResourceCollection res) {
         rcs.add(res);
     }
-    
+
     //mapper takes source files & converts them to dest files
     public Mapper createMapper() throws BuildException {
         if (mapperElement != null) {
@@ -114,12 +114,12 @@ public class CSSEmbedTask extends Task {
         mapperElement = new Mapper(getProject());
         return mapperElement;
     }
-    
+
     //support multiple types of filename mappers being added
     public void add(FileNameMapper fileNameMapper) {
         createMapper().add(fileNameMapper);
     }
-    
+
     //returns the mapper to use based on nested elements, defaults to IdentityMapper
     private FileNameMapper getMapper() {
         FileNameMapper mapper = null;
@@ -130,7 +130,7 @@ public class CSSEmbedTask extends Task {
         }
         return mapper;
     }
-    
+
     //ensure that attributes are legit
     protected void validateAttributes() throws BuildException {
         //if there's no nested resource containers make sure that a srcFile/destFile are set
@@ -138,31 +138,31 @@ public class CSSEmbedTask extends Task {
             if (this.srcFile == null || !this.srcFile.exists()) {
                 throw new BuildException("Must specify an input file or at least one nested resource", getLocation());
             }
-            
+
             if(this.destFile == null) {
                 throw new BuildException("Must specify an output file or at least one nested resource", getLocation());
             }
         }
-        
+
         if(this.mhtml && this.mhtmlRoot == null) {
             throw new BuildException("Must specify mhtmlRoot in mhtml mode", getLocation());
         }
-        
+
         if(this.mhtmlRoot != null && !this.mhtml) {
             log("mhtmlRoot has no effect if mhtml mode is not activated", Project.MSG_WARN);
         }
     }
-    
+
     //run the task
     public void execute () throws BuildException {
         validateAttributes();
-        
+
         //set options flags
         int options = (this.mhtml) ? CSSURLEmbedder.MHTML_OPTION : CSSURLEmbedder.DATAURI_OPTION;
         if(skipMissing) {
             options = options | CSSURLEmbedder.SKIP_MISSING_OPTION;
         }
-        
+
         if(srcFile != null && srcFile.exists()) {
             try {
                 embed(srcFile, destFile, options);
@@ -170,21 +170,21 @@ public class CSSEmbedTask extends Task {
                 throw new BuildException(ex.getMessage(), ex);
             }
         }
-        
+
         FileNameMapper mapper = getMapper();
-        
+
         for(Iterator it = this.rcs.iterator(); it.hasNext();) {
             ResourceCollection rc = (ResourceCollection) it.next();
-            
+
             for(Iterator rcit = rc.iterator(); rcit.hasNext();) {
                 FileResource fr = (FileResource) rcit.next();
                 File in = fr.getFile();
-                
+
                 String[] mapped = mapper.mapFileName(in.getName());
                 if (mapped != null && mapped.length > 0) {
                     for(int k = 0; k < mapped.length; k++) {
                         File out = getProject().resolveFile(in.getParent() + File.separator + mapped[k]);
-                        
+
                         try {
                             embed(in, out, options);
                         } catch(IOException ex) {
@@ -195,45 +195,45 @@ public class CSSEmbedTask extends Task {
             }
         }
     }
-    
+
     private void embed(File input, File output, int options) throws IOException {
         ByteArrayOutputStream bytes = new ByteArrayOutputStream();
         Reader in = new InputStreamReader(new FileInputStream(input), charset);
         Writer out = new OutputStreamWriter(bytes, charset);
         String pathRoot = root;
-        
+
         if(pathRoot == null) {
             pathRoot = input.getCanonicalPath();
-            pathRoot = pathRoot.substring(0, pathRoot.lastIndexOf(File.separator));                
+            pathRoot = pathRoot.substring(0, pathRoot.lastIndexOf(File.separator));
         }
-        
+
         if (!pathRoot.endsWith(File.separator)){
             pathRoot += File.separator;
         }
-        
+
         if(verbose) {
             log("[INFO] embedding images from '" + input + "'");
         }
-        
+
         CSSURLEmbedder embedder = new CSSURLEmbedder(in, options, verbose, maxUriLength, maxImageSize);
-        
+
         if(mhtml) {
             embedder.setMHTMLRoot(mhtmlRoot);
             embedder.setFilename(output.getName());
         }
-        
+
         embedder.embedImages(out, pathRoot);
-        
+
         in.close();
         out.close();
-        
+
         if(bytes.size() > 0) {
             FileOutputStream fos = new FileOutputStream(output);
-            
+
             if(verbose) {
                 log("[INFO] Writing to file: " + output);
             }
-            
+
             bytes.writeTo(fos);
             fos.close();
         }

--- a/src/net/nczonline/web/cssembed/CSSURLEmbedder.java
+++ b/src/net/nczonline/web/cssembed/CSSURLEmbedder.java
@@ -1,17 +1,17 @@
 /*
  * Copyright (c) 2009 Nicholas C. Zakas. All rights reserved.
  * http://www.nczonline.net/
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -20,7 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
- 
+
 package net.nczonline.web.cssembed;
 
 import java.io.BufferedReader;
@@ -41,28 +41,28 @@ import java.util.regex.*;
  * Generator for Data URIs.
  * @author Nicholas C. Zakas
  */
-public class CSSURLEmbedder { 
-    
+public class CSSURLEmbedder {
+
     public static final int DATAURI_OPTION = 1;
     public static final int MHTML_OPTION = 2;
     public static final int SKIP_MISSING_OPTION = 4;
 
     public static final int DEFAULT_MAX_URI_LENGTH = 32768;
-	
+
 	public static final String PROC_DIRECTIVE_PREFIX = "CssEmbed";
 	public static final String PROC_DIRECTIVE_SKIP = "SKIP";
-    
+
     protected static String MHTML_SEPARATOR = "CSSEmbed_Image";
-    
-    private static HashSet<String> imageTypes;    
+
+    private static HashSet<String> imageTypes;
     static {
         imageTypes = new HashSet<String>();
         imageTypes.add("jpg");
         imageTypes.add("jpeg");
         imageTypes.add("gif");
         imageTypes.add("png");
-    }        
-    
+    }
+
     private boolean verbose = false;
     private String code = null;
     private int options = 1;
@@ -70,31 +70,31 @@ public class CSSURLEmbedder {
     private String outputFilename = "";
     private int maxUriLength = DEFAULT_MAX_URI_LENGTH;  //IE8 only allows dataURIs up to 32KB
     private int maxImageSize;
-    
+
     //--------------------------------------------------------------------------
     // Constructors
-    //--------------------------------------------------------------------------    
-    
+    //--------------------------------------------------------------------------
+
     public CSSURLEmbedder(Reader in) throws IOException {
         this(in, false);
     }
-    
+
     public CSSURLEmbedder(Reader in, int options) throws IOException {
         this(in, false);
     }
-    
+
     public CSSURLEmbedder(Reader in, boolean verbose) throws IOException {
         this(in, 1, verbose);
     }
-    
+
     public CSSURLEmbedder(Reader in, int options, boolean verbose) throws IOException {
         this(in, options, verbose, 0);
     }
-    
+
     public CSSURLEmbedder(Reader in, int options, boolean verbose, int maxUriLength) throws IOException {
         this(in, options, verbose, maxUriLength, 0);
     }
-    
+
     public CSSURLEmbedder(Reader in, int options, boolean verbose, int maxUriLength, int maxImageSize) throws IOException {
         this.code = readCode(in);
         this.verbose = verbose;
@@ -105,28 +105,28 @@ public class CSSURLEmbedder {
 
     //--------------------------------------------------------------------------
     // Get/Set verbose flag
-    //--------------------------------------------------------------------------    
-    
+    //--------------------------------------------------------------------------
+
     public boolean getVerbose(){
         return verbose;
     }
-    
+
     public void setVerbose(boolean newVerbose){
         verbose = newVerbose;
     }
-    
+
     //--------------------------------------------------------------------------
     // Determine if an option is set - Options support not yet complete
-    //--------------------------------------------------------------------------    
-    
+    //--------------------------------------------------------------------------
+
     private boolean hasOption(int option){
         return (options & option) > 0;
     }
 
     //--------------------------------------------------------------------------
     // MHTML Support
-    //--------------------------------------------------------------------------    
-    
+    //--------------------------------------------------------------------------
+
     public String getMHTMLRoot(){
         return mhtmlRoot;
     }
@@ -134,19 +134,19 @@ public class CSSURLEmbedder {
     public void setMHTMLRoot(String mhtmlRoot){
         this.mhtmlRoot = mhtmlRoot;
     }
-    
+
     public String getFilename(){
         return outputFilename;
     }
-    
+
     public void setFilename(String filename){
         this.outputFilename = filename;
     }
-    
+
     //--------------------------------------------------------------------------
     // Embed images
     //--------------------------------------------------------------------------
-    
+
     /**
      * Embeds data URI images into a CSS file.
      * @param out The place to write out the source code.
@@ -155,7 +155,7 @@ public class CSSURLEmbedder {
     public void embedImages(Writer out) throws IOException {
         embedImages(out, null);
     }
-        
+
     /**
      * Embeds data URI images into a CSS file.
      * @param out The place to write out the source code.
@@ -163,14 +163,14 @@ public class CSSURLEmbedder {
      * @throws java.io.IOException
      */
     public void embedImages(Writer out, String root) throws IOException {
-        BufferedReader reader = new BufferedReader(new StringReader(code));        
+        BufferedReader reader = new BufferedReader(new StringReader(code));
         StringBuilder builder = new StringBuilder();
         StringBuilder mhtmlHeader = new StringBuilder();
         HashMap<String,Integer> foundMedia = new HashMap<String,Integer>();
         String line;
-        int lineNum = 1;        
+        int lineNum = 1;
         int conversions = 0;
-        
+
         //create initial MHTML code
         if (hasOption(MHTML_OPTION)){
             mhtmlHeader.append("/*\n");
@@ -178,17 +178,17 @@ public class CSSURLEmbedder {
             mhtmlHeader.append(MHTML_SEPARATOR);
             mhtmlHeader.append("\"\n\n");
         }
-        
+
         while((line = reader.readLine()) != null){
-            
+
             int start = 0;
             int pos = line.indexOf("url(", start);
             int npos;
-            
+
             if (lineNum > 1){
                 builder.append("\n");
             }
-			
+
 			Pattern checkForSkip = Pattern.compile("\\/\\*.*" + PROC_DIRECTIVE_PREFIX + ".*" + PROC_DIRECTIVE_SKIP + ".*\\*\\/", Pattern.CASE_INSENSITIVE);
 			Matcher skipMatch = checkForSkip.matcher(line);
 			if (skipMatch.find()) {
@@ -202,32 +202,32 @@ public class CSSURLEmbedder {
                     builder.append(line.substring(start, pos));
                     npos = line.indexOf(")", pos);
                     String url = line.substring(pos, npos).trim();
-                    
+
                     //eliminate quotes at the beginning and end
                     if (url.startsWith("\"")){
                         if (url.endsWith("\"")){
                             url = url.substring(1, url.length()-1);
                         } else {
                             throw new IOException("Invalid CSS URL format (" + url + ") at line " + lineNum + ", col " + pos + ".");
-                        }                        
+                        }
                     } else if (url.startsWith("'")){
                         if (url.endsWith("'")){
                             url = url.substring(1, url.length()-1);
                         } else {
                             throw new IOException("Invalid CSS URL format (" + url + ") at line " + lineNum + ", col " + pos + ".");
-                        }                         
+                        }
                     }
-                    
+
                     //check for duplicates
                     if (foundMedia.containsKey(url)){
                         if (verbose){
                             System.err.println("[WARNING] Duplicate URL '" + url + "' found at line " + lineNum + ", previously declared at line " + foundMedia.get(url) + ".");
-                        }                        
-                    }                    
-                    foundMedia.put(url, lineNum);                    
-                    
+                        }
+                    }
+                    foundMedia.put(url, lineNum);
+
                     //Begin processing URL
-                    String newUrl = url;                    
+                    String newUrl = url;
                     if (verbose){
                         System.err.println("[INFO] Found URL '" + url + "' at line " + lineNum + ", col " + pos + ".");
                     }
@@ -235,18 +235,18 @@ public class CSSURLEmbedder {
                         newUrl = root + url;
                         if (verbose){
                             System.err.println("[INFO] Applying root to URL, URL is now '" + newUrl + "'.");
-                        }                        
+                        }
                     }
-                    
+
                     //get the data URI format
                     String uriString = getImageURIString(newUrl, url);
-                    
+
                     //if it doesn't begin with data:, it's not a data URI
                     if (uriString.startsWith("data:")){
                         if (maxUriLength > 0 && uriString.length() > maxUriLength){
                             if (verbose){
                                 System.err.println("[WARNING] File " + newUrl + " creates a data URI larger than " + maxUriLength + " bytes. Skipping.");
-                            }      
+                            }
                             builder.append(url);
                         } else {
 
@@ -282,10 +282,10 @@ public class CSSURLEmbedder {
                         builder.append(uriString);
                     }
 
-                    start = npos;                    
+                    start = npos;
                     pos = line.indexOf("url(", start);
-                } 
-                
+                }
+
                 //finish out the line
                 if (start < line.length()){
                     builder.append(line.substring(start));
@@ -293,7 +293,7 @@ public class CSSURLEmbedder {
             } else {
                 builder.append(line);
             }
-            
+
             lineNum++;
         }
         reader.close();
@@ -309,16 +309,16 @@ public class CSSURLEmbedder {
             mhtmlHeader.append("*/\n");
             out.write(mhtmlHeader.toString());
         }
-        
+
         if (verbose){
             System.err.println("[INFO] Converted " + conversions + " images to data URIs.");
         }
 
-        out.write(builder.toString());        
+        out.write(builder.toString());
     }
-    
+
     /**
-     * Returns a URI string for the given URL. If the URL is for an image, 
+     * Returns a URI string for the given URL. If the URL is for an image,
      * the data URI will be returned. If the URL is not for an image, then the
      * original URI is returned.
      * @param url The URL to attempt to read.
@@ -327,80 +327,80 @@ public class CSSURLEmbedder {
      * @throws java.io.IOException
      */
     String getImageURIString(String url, String originalUrl) throws IOException {
-        
+
         //it's an image, so encode it
         if (isImage(url)){
-            
+
             DataURIGenerator.setVerbose(verbose);
-                
+
             StringWriter writer = new StringWriter();
-            
+
             try {
                 if (url.startsWith("http://")){
                     if (verbose){
                         System.err.println("[INFO] Downloading '" + url + "' to generate data URI.");
-                    }                
-                    
-                    DataURIGenerator.generate(new URL(url), writer); 
-                  
+                    }
+
+                    DataURIGenerator.generate(new URL(url), writer);
+
                 } else {
                     if (verbose){
                         System.err.println("[INFO] Opening file '" + url + "' to generate data URI.");
-                    }                
-                    
+                    }
+
                     File file = new File(url);
-                    
+
                     if (verbose && !file.isFile()){
                         System.err.println("[INFO] Could not find file '" + file.getCanonicalPath() + "'.");
                     }
-                    
+
                     //check file size if we've been asked to
                     if (maxImageSize > 0 && file.length() > maxImageSize){
                         if (verbose){
                             System.err.println("[INFO] File '" + originalUrl + "' is larger than " + maxImageSize + " bytes. Skipping.");
                         }
-                        
+
                         writer.write(originalUrl);
-                        
+
                     } else {
-                        DataURIGenerator.generate(new File(url), writer); 
+                        DataURIGenerator.generate(new File(url), writer);
                     }
                 }
 
                 if (verbose){
                     System.err.println("[INFO] Generated data URI for '" + url + "'.");
                 }
-            } catch (FileNotFoundException e){ 
+            } catch (FileNotFoundException e){
                 if(hasOption(SKIP_MISSING_OPTION)) {
                     if (verbose){
                         System.err.println("[INFO] Could not find file. " + e.getMessage() + " Skipping.");
                     }
-                
+
                     writer.write(originalUrl);
                 } else {
                     throw e;
                 }
             }
-            
+
             return writer.toString();
-            
+
         } else {
-            
+
             if (verbose){
                 System.err.println("[INFO] URL '" + originalUrl + "' is not an image, skipping.");
             }
-            
+
             //not an image, ignore
             return originalUrl;
         }
-        
+
     }
 
     /*
      * Detects if the given url represents an image
-     * This method simply checks the file extension. 
-     * A better way to detect an image is via content type response headers or by content sniffing, 
-     * but both are expensive approaches. We can do without them for now. 
+     * This method simply checks the file extension.
+     * A better way to detect an image is via content type response headers or by content sniffing,
+     * but both are expensive approaches. We can do without them for now.
      */
     static boolean isImage(String url) {
     	int startPos = url.lastIndexOf(".") + 1;
@@ -424,28 +424,28 @@ public class CSSURLEmbedder {
             return path;
         }
     }
-    
+
     private String getMHTMLPath(){
         String result = mhtmlRoot;
         if (!result.endsWith("/")){
             result += "/";
         }
-        
+
         result += outputFilename;
-        
+
         return result;
     }
-    
+
     private String readCode(Reader in) throws IOException {
         StringBuilder builder = new StringBuilder();
         int c;
-        
+
         while ((c = in.read()) != -1){
             builder.append((char)c);
         }
-        
+
         in.close();
         return builder.toString();
     }
-            
+
 }

--- a/src/net/nczonline/web/cssembed/CSSURLEmbedder.java
+++ b/src/net/nczonline/web/cssembed/CSSURLEmbedder.java
@@ -46,6 +46,7 @@ public class CSSURLEmbedder {
     public static final int DATAURI_OPTION = 1;
     public static final int MHTML_OPTION = 2;
     public static final int SKIP_MISSING_OPTION = 4;
+    public static final int MHTML_FILE_OPTION = 8;
 
     public static final int DEFAULT_MAX_URI_LENGTH = 32768;
 
@@ -153,7 +154,7 @@ public class CSSURLEmbedder {
      * @throws java.io.IOException
      */
     public void embedImages(Writer cssOut) throws IOException {
-        embedImages(cssOut, null);
+        embedImages(cssOut, null, null);
     }
 
     /**
@@ -163,6 +164,17 @@ public class CSSURLEmbedder {
      * @throws java.io.IOException
      */
     public void embedImages(Writer cssOut, String root) throws IOException {
+        embedImages(cssOut, null, root);
+    }
+
+    /**
+     * Embeds data URI images into a CSS file.
+     * @param cssOut The place to write out the CSS source code.
+     * @param mhtmlOut The place to write out the MHTML source code.
+     * @param root The root to prepend to any relative paths.
+     * @throws java.io.IOException
+     */
+    public void embedImages(Writer cssOut, Writer mhtmlOut, String root) throws IOException {
         BufferedReader reader = new BufferedReader(new StringReader(code));
         StringBuilder cssBuilder = new StringBuilder();
         StringBuilder mhtmlBuilder = new StringBuilder();
@@ -173,7 +185,6 @@ public class CSSURLEmbedder {
 
         //create initial MHTML code
         if (hasOption(MHTML_OPTION)){
-            mhtmlBuilder.append("/*\n");
             mhtmlBuilder.append("Content-Type: multipart/related; boundary=\"");
             mhtmlBuilder.append(MHTML_SEPARATOR);
             mhtmlBuilder.append("\"\n\n");
@@ -305,9 +316,15 @@ public class CSSURLEmbedder {
             mhtmlBuilder.append(MHTML_SEPARATOR);
             mhtmlBuilder.append("--\n");
 
-            //close comment
-            mhtmlBuilder.append("*/\n");
-            cssOut.write(mhtmlBuilder.toString());
+        	if (hasOption(MHTML_FILE_OPTION)) {
+        		// write MHTML output to MHTML file
+        		mhtmlOut.write(mhtmlBuilder.toString());
+        	} else {
+        		// wrap MHTML output in comments, write to CSS file
+        		cssOut.write("/*\n");
+        		cssOut.write(mhtmlBuilder.toString());
+        		cssOut.write("*/\n");
+        	}
         }
 
         if (verbose){

--- a/src/net/nczonline/web/cssembed/CSSURLEmbedder.java
+++ b/src/net/nczonline/web/cssembed/CSSURLEmbedder.java
@@ -55,6 +55,8 @@ public class CSSURLEmbedder {
 
     protected static String MHTML_SEPARATOR = "CSSEmbed_Image";
 
+    private static final String LINE_END = "\n";
+
     private static HashSet<String> imageTypes;
     static {
         imageTypes = new HashSet<String>();
@@ -187,7 +189,7 @@ public class CSSURLEmbedder {
         if (hasOption(MHTML_OPTION)){
             mhtmlBuilder.append("Content-Type: multipart/related; boundary=\"");
             mhtmlBuilder.append(MHTML_SEPARATOR);
-            mhtmlBuilder.append("\"\n\n");
+            mhtmlBuilder.append("\"").append(LINE_END).append(LINE_END);
         }
 
         while((line = reader.readLine()) != null){
@@ -197,7 +199,7 @@ public class CSSURLEmbedder {
             int npos;
 
             if (lineNum > 1){
-                cssBuilder.append("\n");
+                cssBuilder.append(LINE_END);
             }
 
 			Pattern checkForSkip = Pattern.compile("\\/\\*.*" + PROC_DIRECTIVE_PREFIX + ".*" + PROC_DIRECTIVE_SKIP + ".*\\*\\/", Pattern.CASE_INSENSITIVE);
@@ -268,14 +270,16 @@ public class CSSURLEmbedder {
                             if (hasOption(MHTML_OPTION)){
                                 String entryName = getFilename(url);
 
-                                //create MHTML header entry
+                                //add MHTML content part
+                                mhtmlBuilder.append(LINE_END);
                                 mhtmlBuilder.append("--");
-                                mhtmlBuilder.append(MHTML_SEPARATOR);
-                                mhtmlBuilder.append("\nContent-Location:");
-                                mhtmlBuilder.append(entryName);
-                                mhtmlBuilder.append("\nContent-Transfer-Encoding:base64\n\n");
+                                mhtmlBuilder.append(MHTML_SEPARATOR).append(LINE_END);
+                                mhtmlBuilder.append("Content-Location:");
+                                mhtmlBuilder.append(entryName).append(LINE_END);
+                                mhtmlBuilder.append("Content-Transfer-Encoding:base64");
+                                mhtmlBuilder.append(LINE_END).append(LINE_END);
                                 mhtmlBuilder.append(uriString.substring(uriString.indexOf(",")+1));
-                                mhtmlBuilder.append("\n");
+                                mhtmlBuilder.append(LINE_END);
 
                                 //output the URI
                                 cssBuilder.append("mhtml:");
@@ -312,18 +316,19 @@ public class CSSURLEmbedder {
         if (hasOption(MHTML_OPTION) && conversions > 0){
 
             //Add one more boundary to fix IE/Vista issue
-            mhtmlBuilder.append("\n--");
+        	mhtmlBuilder.append(LINE_END);
+            mhtmlBuilder.append("--");
             mhtmlBuilder.append(MHTML_SEPARATOR);
-            mhtmlBuilder.append("--\n");
+            mhtmlBuilder.append("--").append(LINE_END);
 
         	if (hasOption(MHTML_FILE_OPTION)) {
         		// write MHTML output to MHTML file
         		mhtmlOut.write(mhtmlBuilder.toString());
         	} else {
         		// wrap MHTML output in comments, write to CSS file
-        		cssOut.write("/*\n");
+        		cssOut.write("/*" + LINE_END);
         		cssOut.write(mhtmlBuilder.toString());
-        		cssOut.write("*/\n");
+        		cssOut.write("*/"+ LINE_END);
         	}
         }
 

--- a/src/net/nczonline/web/datauri/Base64.java
+++ b/src/net/nczonline/web/datauri/Base64.java
@@ -4,16 +4,16 @@ package net.nczonline.web.datauri;
 /**
  * <p>Encodes and decodes to and from Base64 notation.</p>
  * <p>Homepage: <a href="http://iharder.net/base64">http://iharder.net/base64</a>.</p>
- * 
+ *
  * <p>Example:</p>
- * 
+ *
  * <code>String encoded = Base64.encode( myByteArray );</code>
  * <br />
  * <code>byte[] myByteArray = Base64.decode( encoded );</code>
  *
- * <p>The <tt>options</tt> parameter, which appears in a few places, is used to pass 
- * several pieces of information to the encoder. In the "higher level" methods such as 
- * encodeBytes( bytes, options ) the options parameter can be used to indicate such 
+ * <p>The <tt>options</tt> parameter, which appears in a few places, is used to pass
+ * several pieces of information to the encoder. In the "higher level" methods such as
+ * encodeBytes( bytes, options ) the options parameter can be used to indicate such
  * things as first gzipping the bytes before encoding them, not inserting linefeeds,
  * and encoding using the URL-safe and Ordered dialects.</p>
  *
@@ -22,7 +22,7 @@ package net.nczonline.web.datauri;
  * to do so. I've got Base64 set to this behavior now, although earlier versions
  * broke lines by default.</p>
  *
- * <p>The constants defined in Base64 can be OR-ed together to combine options, so you 
+ * <p>The constants defined in Base64 can be OR-ed together to combine options, so you
  * might make a call like this:</p>
  *
  * <code>String encoded = Base64.encodeBytes( mybytes, Base64.GZIP | Base64.DO_BREAK_LINES );</code>
@@ -60,7 +60,7 @@ package net.nczonline.web.datauri;
  *  <li>v2.3 - <strong>This is not a drop-in replacement!</strong> This is two years of comments
  *   and bug fixes queued up and finally executed. Thanks to everyone who sent
  *   me stuff, and I'm sorry I wasn't able to distribute your fixes to everyone else.
- *   Much bad coding was cleaned up including throwing exceptions where necessary 
+ *   Much bad coding was cleaned up including throwing exceptions where necessary
  *   instead of returning null values or something similar. Here are some changes
  *   that may affect you:
  *   <ul>
@@ -98,24 +98,24 @@ package net.nczonline.web.datauri;
  *   Special thanks to Jim Kellerman at <a href="http://www.powerset.com/">http://www.powerset.com/</a>
  *   for contributing the new Base64 dialects.
  *  </li>
- * 
+ *
  *  <li>v2.1 - Cleaned up javadoc comments and unused variables and methods. Added
  *   some convenience methods for reading and writing to and from files.</li>
  *  <li>v2.0.2 - Now specifies UTF-8 encoding in places where the code fails on systems
  *   with other encodings (like EBCDIC).</li>
  *  <li>v2.0.1 - Fixed an error when decoding a single byte, that is, when the
  *   encoded data was a single byte.</li>
- *  <li>v2.0 - I got rid of methods that used booleans to set options. 
+ *  <li>v2.0 - I got rid of methods that used booleans to set options.
  *   Now everything is more consolidated and cleaner. The code now detects
  *   when data that's being decoded is gzip-compressed and will decompress it
  *   automatically. Generally things are cleaner. You'll probably have to
  *   change some method calls that you were making to support the new
  *   options format (<tt>int</tt>s that you "OR" together).</li>
- *  <li>v1.5.1 - Fixed bug when decompressing and decoding to a             
- *   byte[] using <tt>decode( String s, boolean gzipCompressed )</tt>.      
- *   Added the ability to "suspend" encoding in the Output Stream so        
- *   you can turn on and off the encoding if you need to embed base64       
- *   data in an otherwise "normal" stream (like an XML file).</li>  
+ *  <li>v1.5.1 - Fixed bug when decompressing and decoding to a
+ *   byte[] using <tt>decode( String s, boolean gzipCompressed )</tt>.
+ *   Added the ability to "suspend" encoding in the Output Stream so
+ *   you can turn on and off the encoding if you need to embed base64
+ *   data in an otherwise "normal" stream (like an XML file).</li>
  *  <li>v1.5 - Output stream pases on flush() command but doesn't do anything itself.
  *      This helps when using GZIP streams.
  *      Added the ability to GZip-compress objects before encoding them.</li>
@@ -141,36 +141,36 @@ package net.nczonline.web.datauri;
  */
 public class Base64
 {
-    
-/* ********  P U B L I C   F I E L D S  ******** */   
-    
-    
+
+/* ********  P U B L I C   F I E L D S  ******** */
+
+
     /** No options specified. Value is zero. */
     public final static int NO_OPTIONS = 0;
-    
+
     /** Specify encoding in first bit. Value is one. */
     public final static int ENCODE = 1;
-    
-    
+
+
     /** Specify decoding in first bit. Value is zero. */
     public final static int DECODE = 0;
-    
+
 
     /** Specify that data should be gzip-compressed in second bit. Value is two. */
     public final static int GZIP = 2;
 
     /** Specify that gzipped data should <em>not</em> be automatically gunzipped. */
     public final static int DONT_GUNZIP = 4;
-    
-    
+
+
     /** Do break lines when encoding. Value is 8. */
     public final static int DO_BREAK_LINES = 8;
-	
-    /** 
+
+    /**
      * Encode using Base64-like encoding that is URL- and Filename-safe as described
-     * in Section 4 of RFC3548: 
+     * in Section 4 of RFC3548:
      * <a href="http://www.faqs.org/rfcs/rfc3548.html">http://www.faqs.org/rfcs/rfc3548.html</a>.
-     * It is important to note that data encoded this way is <em>not</em> officially valid Base64, 
+     * It is important to note that data encoded this way is <em>not</em> officially valid Base64,
      * or at the very least should not be called Base64 without also specifying that is
      * was encoded using the URL- and Filename-safe dialect.
      */
@@ -182,50 +182,50 @@ public class Base64
       * <a href="http://www.faqs.org/qa/rfcc-1940.html">http://www.faqs.org/qa/rfcc-1940.html</a>.
       */
      public final static int ORDERED = 32;
-    
-    
-/* ********  P R I V A T E   F I E L D S  ******** */  
-    
-    
+
+
+/* ********  P R I V A T E   F I E L D S  ******** */
+
+
     /** Maximum line length (76) of Base64 output. */
     private final static int MAX_LINE_LENGTH = 76;
-    
-    
+
+
     /** The equals sign (=) as a byte. */
     private final static byte EQUALS_SIGN = (byte)'=';
-    
-    
+
+
     /** The new line character (\n) as a byte. */
     private final static byte NEW_LINE = (byte)'\n';
-    
-    
+
+
     /** Preferred encoding. */
     private final static String PREFERRED_ENCODING = "US-ASCII";
-    
-	
+
+
     private final static byte WHITE_SPACE_ENC = -5; // Indicates white space in encoding
     private final static byte EQUALS_SIGN_ENC = -1; // Indicates equals sign in encoding
-	
-	
-/* ********  S T A N D A R D   B A S E 6 4   A L P H A B E T  ******** */	
-    
+
+
+/* ********  S T A N D A R D   B A S E 6 4   A L P H A B E T  ******** */
+
     /** The 64 valid Base64 values. */
     /* Host platform me be something funny like EBCDIC, so we hardcode these values. */
     private final static byte[] _STANDARD_ALPHABET = {
         (byte)'A', (byte)'B', (byte)'C', (byte)'D', (byte)'E', (byte)'F', (byte)'G',
         (byte)'H', (byte)'I', (byte)'J', (byte)'K', (byte)'L', (byte)'M', (byte)'N',
-        (byte)'O', (byte)'P', (byte)'Q', (byte)'R', (byte)'S', (byte)'T', (byte)'U', 
+        (byte)'O', (byte)'P', (byte)'Q', (byte)'R', (byte)'S', (byte)'T', (byte)'U',
         (byte)'V', (byte)'W', (byte)'X', (byte)'Y', (byte)'Z',
         (byte)'a', (byte)'b', (byte)'c', (byte)'d', (byte)'e', (byte)'f', (byte)'g',
         (byte)'h', (byte)'i', (byte)'j', (byte)'k', (byte)'l', (byte)'m', (byte)'n',
-        (byte)'o', (byte)'p', (byte)'q', (byte)'r', (byte)'s', (byte)'t', (byte)'u', 
+        (byte)'o', (byte)'p', (byte)'q', (byte)'r', (byte)'s', (byte)'t', (byte)'u',
         (byte)'v', (byte)'w', (byte)'x', (byte)'y', (byte)'z',
-        (byte)'0', (byte)'1', (byte)'2', (byte)'3', (byte)'4', (byte)'5', 
+        (byte)'0', (byte)'1', (byte)'2', (byte)'3', (byte)'4', (byte)'5',
         (byte)'6', (byte)'7', (byte)'8', (byte)'9', (byte)'+', (byte)'/'
     };
-	
-    
-    /** 
+
+
+    /**
      * Translates a Base64 value to either its 6-bit reconstruction value
      * or a negative number indicating some other meaning.
      **/
@@ -262,28 +262,28 @@ public class Base64
         -9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,     // Decimal 231 - 243
         -9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9         // Decimal 244 - 255 */
     };
-	
-	
+
+
 /* ********  U R L   S A F E   B A S E 6 4   A L P H A B E T  ******** */
-	
+
     /**
-     * Used in the URL- and Filename-safe dialect described in Section 4 of RFC3548: 
+     * Used in the URL- and Filename-safe dialect described in Section 4 of RFC3548:
      * <a href="http://www.faqs.org/rfcs/rfc3548.html">http://www.faqs.org/rfcs/rfc3548.html</a>.
      * Notice that the last two bytes become "hyphen" and "underscore" instead of "plus" and "slash."
      */
     private final static byte[] _URL_SAFE_ALPHABET = {
       (byte)'A', (byte)'B', (byte)'C', (byte)'D', (byte)'E', (byte)'F', (byte)'G',
       (byte)'H', (byte)'I', (byte)'J', (byte)'K', (byte)'L', (byte)'M', (byte)'N',
-      (byte)'O', (byte)'P', (byte)'Q', (byte)'R', (byte)'S', (byte)'T', (byte)'U', 
+      (byte)'O', (byte)'P', (byte)'Q', (byte)'R', (byte)'S', (byte)'T', (byte)'U',
       (byte)'V', (byte)'W', (byte)'X', (byte)'Y', (byte)'Z',
       (byte)'a', (byte)'b', (byte)'c', (byte)'d', (byte)'e', (byte)'f', (byte)'g',
       (byte)'h', (byte)'i', (byte)'j', (byte)'k', (byte)'l', (byte)'m', (byte)'n',
-      (byte)'o', (byte)'p', (byte)'q', (byte)'r', (byte)'s', (byte)'t', (byte)'u', 
+      (byte)'o', (byte)'p', (byte)'q', (byte)'r', (byte)'s', (byte)'t', (byte)'u',
       (byte)'v', (byte)'w', (byte)'x', (byte)'y', (byte)'z',
-      (byte)'0', (byte)'1', (byte)'2', (byte)'3', (byte)'4', (byte)'5', 
+      (byte)'0', (byte)'1', (byte)'2', (byte)'3', (byte)'4', (byte)'5',
       (byte)'6', (byte)'7', (byte)'8', (byte)'9', (byte)'-', (byte)'_'
     };
-	
+
     /**
      * Used in decoding URL- and Filename-safe dialects of Base64.
      */
@@ -348,7 +348,7 @@ public class Base64
       (byte)'o', (byte)'p', (byte)'q', (byte)'r', (byte)'s', (byte)'t', (byte)'u',
       (byte)'v', (byte)'w', (byte)'x', (byte)'y', (byte)'z'
     };
-	
+
     /**
      * Used in decoding the "ordered" dialect of Base64.
      */
@@ -390,7 +390,7 @@ public class Base64
         -9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9         // Decimal 244 - 255 */
     };
 
-	
+
 /* ********  D E T E R M I N E   W H I C H   A L H A B E T  ******** */
 
 
@@ -430,16 +430,16 @@ public class Base64
     }	// end getAlphabet
 
 
-    
+
     /** Defeats instantiation. */
     private Base64(){}
-    
 
-    
-    
-/* ********  E N C O D I N G   M E T H O D S  ******** */    
-    
-    
+
+
+
+/* ********  E N C O D I N G   M E T H O D S  ******** */
+
+
     /**
      * Encodes up to the first three bytes of array <var>threeBytes</var>
      * and returns a four-byte array in Base64 notation.
@@ -460,12 +460,12 @@ public class Base64
         return b4;
     }   // end encode3to4
 
-    
+
     /**
      * <p>Encodes up to three bytes of the array <var>source</var>
      * and writes the resulting four Base64 bytes to <var>destination</var>.
      * The source and destination arrays can be manipulated
-     * anywhere along their length by specifying 
+     * anywhere along their length by specifying
      * <var>srcOffset</var> and <var>destOffset</var>.
      * This method does not check to make sure your arrays
      * are large enough to accomodate <var>srcOffset</var> + 3 for
@@ -484,19 +484,19 @@ public class Base64
      * @return the <var>destination</var> array
      * @since 1.3
      */
-    private static byte[] encode3to4( 
+    private static byte[] encode3to4(
     byte[] source, int srcOffset, int numSigBytes,
     byte[] destination, int destOffset, int options ) {
-        
-	byte[] ALPHABET = getAlphabet( options ); 
-	
-        //           1         2         3  
+
+	byte[] ALPHABET = getAlphabet( options );
+
+        //           1         2         3
         // 01234567890123456789012345678901 Bit position
         // --------000000001111111122222222 Array position from threeBytes
         // --------|    ||    ||    ||    | Six bit groups to index ALPHABET
         //          >>18  >>12  >> 6  >> 0  Right shift necessary
         //                0x3f  0x3f  0x3f  Additional AND
-        
+
         // Create buffer with zero-padding if there are only one or two
         // significant bytes passed in the array.
         // We have to shift left 24 in order to flush out the 1's that appear
@@ -513,21 +513,21 @@ public class Base64
                 destination[ destOffset + 2 ] = ALPHABET[ (inBuff >>>  6) & 0x3f ];
                 destination[ destOffset + 3 ] = ALPHABET[ (inBuff       ) & 0x3f ];
                 return destination;
-                
+
             case 2:
                 destination[ destOffset     ] = ALPHABET[ (inBuff >>> 18)        ];
                 destination[ destOffset + 1 ] = ALPHABET[ (inBuff >>> 12) & 0x3f ];
                 destination[ destOffset + 2 ] = ALPHABET[ (inBuff >>>  6) & 0x3f ];
                 destination[ destOffset + 3 ] = EQUALS_SIGN;
                 return destination;
-                
+
             case 1:
                 destination[ destOffset     ] = ALPHABET[ (inBuff >>> 18)        ];
                 destination[ destOffset + 1 ] = ALPHABET[ (inBuff >>> 12) & 0x3f ];
                 destination[ destOffset + 2 ] = EQUALS_SIGN;
                 destination[ destOffset + 3 ] = EQUALS_SIGN;
                 return destination;
-                
+
             default:
                 return destination;
         }   // end switch
@@ -585,18 +585,18 @@ public class Base64
     }
 
 
-    
-    
+
+
     /**
      * Serializes an object and returns the Base64-encoded
-     * version of that serialized object.  
-     *  
+     * version of that serialized object.
+     *
      * <p>As of v 2.3, if the object
      * cannot be serialized or there is another error,
      * the method will throw an java.io.IOException. <b>This is new to v2.3!</b>
      * In earlier versions, it just returned a null value, but
      * in retrospect that's a pretty poor way to handle it.</p>
-     * 
+     *
      * The object is not GZip-compressed before being encoded.
      *
      * @param serializableObject The object to encode
@@ -609,19 +609,19 @@ public class Base64
     throws java.io.IOException {
         return encodeObject( serializableObject, NO_OPTIONS );
     }   // end encodeObject
-    
+
 
 
     /**
      * Serializes an object and returns the Base64-encoded
      * version of that serialized object.
-     *  
+     *
      * <p>As of v 2.3, if the object
      * cannot be serialized or there is another error,
      * the method will throw an java.io.IOException. <b>This is new to v2.3!</b>
      * In earlier versions, it just returned a null value, but
      * in retrospect that's a pretty poor way to handle it.</p>
-     * 
+     *
      * The object is not GZip-compressed before being encoded.
      * <p>
      * Example options:<pre>
@@ -647,14 +647,14 @@ public class Base64
         if( serializableObject == null ){
             throw new NullPointerException( "Cannot serialize a null object." );
         }   // end if: null
-        
+
         // Streams
-        java.io.ByteArrayOutputStream  baos  = null; 
+        java.io.ByteArrayOutputStream  baos  = null;
         java.io.OutputStream           b64os = null;
         java.util.zip.GZIPOutputStream gzos  = null;
         java.io.ObjectOutputStream     oos   = null;
-        
-        
+
+
         try {
             // ObjectOutputStream -> (GZIP) -> Base64 -> ByteArrayOutputStream
             baos  = new java.io.ByteArrayOutputStream();
@@ -680,7 +680,7 @@ public class Base64
             try{ b64os.close(); } catch( Exception e ){}
             try{ baos.close();  } catch( Exception e ){}
         }   // end finally
-        
+
         // Return value according to relevant encoding.
         try {
             return new String( baos.toByteArray(), PREFERRED_ENCODING );
@@ -689,15 +689,15 @@ public class Base64
             // Fall back to some Java default
             return new String( baos.toByteArray() );
         }   // end catch
-        
+
     }   // end encode
-    
-    
+
+
 
     /**
      * Encodes a byte array into Base64 notation.
      * Does not GZip-compress data.
-     *  
+     *
      * @param source The data to convert
      * @return The data in Base64-encoded form
      * @throws NullPointerException if source array is null
@@ -716,7 +716,7 @@ public class Base64
         assert encoded != null;
         return encoded;
     }   // end encodeBytes
-    
+
 
 
     /**
@@ -732,12 +732,12 @@ public class Base64
      * <p>
      * Example: <code>encodeBytes( myData, Base64.GZIP | Base64.DO_BREAK_LINES )</code>
      *
-     *  
+     *
      * <p>As of v 2.3, if there is an error with the GZIP stream,
      * the method will throw an java.io.IOException. <b>This is new to v2.3!</b>
      * In earlier versions, it just returned a null value, but
      * in retrospect that's a pretty poor way to handle it.</p>
-     * 
+     *
      *
      * @param source The data to convert
      * @param options Specified options
@@ -751,17 +751,17 @@ public class Base64
     public static String encodeBytes( byte[] source, int options ) throws java.io.IOException {
         return encodeBytes( source, 0, source.length, options );
     }   // end encodeBytes
-    
-    
+
+
     /**
      * Encodes a byte array into Base64 notation.
      * Does not GZip-compress data.
-     *  
+     *
      * <p>As of v 2.3, if there is an error,
      * the method will throw an java.io.IOException. <b>This is new to v2.3!</b>
      * In earlier versions, it just returned a null value, but
      * in retrospect that's a pretty poor way to handle it.</p>
-     * 
+     *
      *
      * @param source The data to convert
      * @param off Offset in array where conversion should begin
@@ -784,8 +784,8 @@ public class Base64
         assert encoded != null;
         return encoded;
     }   // end encodeBytes
-    
-    
+
+
 
     /**
      * Encodes a byte array into Base64 notation.
@@ -800,12 +800,12 @@ public class Base64
      * <p>
      * Example: <code>encodeBytes( myData, Base64.GZIP | Base64.DO_BREAK_LINES )</code>
      *
-     *  
+     *
      * <p>As of v 2.3, if there is an error with the GZIP stream,
      * the method will throw an java.io.IOException. <b>This is new to v2.3!</b>
      * In earlier versions, it just returned a null value, but
      * in retrospect that's a pretty poor way to handle it.</p>
-     * 
+     *
      *
      * @param source The data to convert
      * @param off Offset in array where conversion should begin
@@ -829,7 +829,7 @@ public class Base64
         catch (java.io.UnsupportedEncodingException uue) {
             return new String( encoded );
         }   // end catch
-        
+
     }   // end encodeBytes
 
 
@@ -975,34 +975,34 @@ public class Base64
                 //System.err.println("No need to resize array.");
                 return outBuff;
             }
-        
+
         }   // end else: don't compress
 
     }   // end encodeBytesToBytes
-    
 
-    
-    
-    
+
+
+
+
 /* ********  D E C O D I N G   M E T H O D S  ******** */
-    
-    
+
+
     /**
      * Decodes four bytes from array <var>source</var>
      * and writes the resulting bytes (up to three of them)
      * to <var>destination</var>.
      * The source and destination arrays can be manipulated
-     * anywhere along their length by specifying 
+     * anywhere along their length by specifying
      * <var>srcOffset</var> and <var>destOffset</var>.
      * This method does not check to make sure your arrays
      * are large enough to accomodate <var>srcOffset</var> + 4 for
      * the <var>source</var> array or <var>destOffset</var> + 3 for
      * the <var>destination</var> array.
-     * This method returns the actual number of bytes that 
+     * This method returns the actual number of bytes that
      * were converted from the Base64 encoding.
 	 * <p>This is the lowest level of the decoding methods with
 	 * all possible parameters.</p>
-     * 
+     *
      *
      * @param source the array to convert
      * @param srcOffset the index where conversion begins
@@ -1015,10 +1015,10 @@ public class Base64
      *         or there is not enough room in the array.
      * @since 1.3
      */
-    private static int decode4to3( 
-    byte[] source, int srcOffset, 
+    private static int decode4to3(
+    byte[] source, int srcOffset,
     byte[] destination, int destOffset, int options ) {
-        
+
         // Lots of error checking and exception throwing
         if( source == null ){
             throw new NullPointerException( "Source array was null." );
@@ -1027,17 +1027,17 @@ public class Base64
             throw new NullPointerException( "Destination array was null." );
         }   // end if
         if( srcOffset < 0 || srcOffset + 3 >= source.length ){
-            throw new IllegalArgumentException( 
+            throw new IllegalArgumentException(
             "Source array with length " + source.length + " cannot have offset of " + srcOffset + " and still process four bytes.");
         }   // end if
         if( destOffset < 0 || destOffset +2 >= destination.length ){
             throw new IllegalArgumentException(
             "Destination array with length " + destination.length + " cannot have offset of " );
         }   // end if
-        
-        
-        byte[] DECODABET = getDecodabet( options ); 
-	
+
+
+        byte[] DECODABET = getDecodabet( options );
+
         // Example: Dk==
         if( source[ srcOffset + 2] == EQUALS_SIGN ) {
             // Two ways to do the same thing. Don't know which way I like best.
@@ -1045,11 +1045,11 @@ public class Base64
           //              | ( ( DECODABET[ source[ srcOffset + 1] ] << 24 ) >>> 12 );
             int outBuff =   ( ( DECODABET[ source[ srcOffset    ] ] & 0xFF ) << 18 )
                           | ( ( DECODABET[ source[ srcOffset + 1] ] & 0xFF ) << 12 );
-            
+
             destination[ destOffset ] = (byte)( outBuff >>> 16 );
             return 1;
         }
-        
+
         // Example: DkL=
         else if( source[ srcOffset + 3 ] == EQUALS_SIGN ) {
             // Two ways to do the same thing. Don't know which way I like best.
@@ -1059,12 +1059,12 @@ public class Base64
             int outBuff =   ( ( DECODABET[ source[ srcOffset     ] ] & 0xFF ) << 18 )
                           | ( ( DECODABET[ source[ srcOffset + 1 ] ] & 0xFF ) << 12 )
                           | ( ( DECODABET[ source[ srcOffset + 2 ] ] & 0xFF ) <<  6 );
-            
+
             destination[ destOffset     ] = (byte)( outBuff >>> 16 );
             destination[ destOffset + 1 ] = (byte)( outBuff >>>  8 );
             return 2;
         }
-        
+
         // Example: DkLE
         else {
             // Two ways to do the same thing. Don't know which way I like best.
@@ -1077,7 +1077,7 @@ public class Base64
                           | ( ( DECODABET[ source[ srcOffset + 2 ] ] & 0xFF ) <<  6)
                           | ( ( DECODABET[ source[ srcOffset + 3 ] ] & 0xFF )      );
 
-            
+
             destination[ destOffset     ] = (byte)( outBuff >> 16 );
             destination[ destOffset + 1 ] = (byte)( outBuff >>  8 );
             destination[ destOffset + 2 ] = (byte)( outBuff       );
@@ -1085,7 +1085,7 @@ public class Base64
             return 3;
         }
     }   // end decodeToBytes
-    
+
 
 
 
@@ -1113,8 +1113,8 @@ public class Base64
         return decoded;
     }
 
-    
-    
+
+
     /**
      * Low-level access to decoding ASCII characters in
      * the form of a byte array. <strong>Ignores GUNZIP option, if
@@ -1134,7 +1134,7 @@ public class Base64
      */
     public static byte[] decode( byte[] source, int off, int len, int options )
     throws java.io.IOException {
-        
+
         // Lots of error checking and exception throwing
         if( source == null ){
             throw new NullPointerException( "Cannot decode null source array." );
@@ -1143,31 +1143,31 @@ public class Base64
             throw new IllegalArgumentException(
             "Source array with length " + source.length + " cannot have offset of " + off + " and process " + len + " bytes." );
         }   // end if
-        
+
         if( len == 0 ){
             return new byte[0];
         }else if( len < 4 ){
-            throw new IllegalArgumentException( 
+            throw new IllegalArgumentException(
             "Base64-encoded string must have at least four characters, but length specified was " + len );
         }   // end if
-        
+
         byte[] DECODABET = getDecodabet( options );
-	
+
         int    len34   = len * 3 / 4;       // Estimate on array size
         byte[] outBuff = new byte[ len34 ]; // Upper limit on size of output
         int    outBuffPosn = 0;             // Keep track of where we're writing
-        
+
         byte[] b4        = new byte[4];     // Four byte buffer from source, eliminating white space
         int    b4Posn    = 0;               // Keep track of four byte input buffer
         int    i         = 0;               // Source array counter
         byte   sbiCrop   = 0;               // Low seven bits (ASCII) of input
         byte   sbiDecode = 0;               // Special value from DECODABET
-        
+
         for( i = off; i < off+len; i++ ) {  // Loop through source
-            
+
             sbiCrop = (byte)(source[i] & 0x7f); // Only the low seven bits
             sbiDecode = DECODABET[ sbiCrop ];   // Special value
-            
+
             // White space, Equals sign, or legit Base64 character
             // Note the values such as -5 and -9 in the
             // DECODABETs at the top of the file.
@@ -1177,7 +1177,7 @@ public class Base64
                     if( b4Posn > 3 ) {                  // Time to decode?
                         outBuffPosn += decode4to3( b4, 0, outBuff, outBuffPosn, options );
                         b4Posn = 0;
-                        
+
                         // If that was the equals sign, break out of 'for' loop
                         if( sbiCrop == EQUALS_SIGN ) {
                             break;
@@ -1187,19 +1187,19 @@ public class Base64
             }   // end if: white space, equals sign or better
             else {
                 // There's a bad input character in the Base64 stream.
-                throw new java.io.IOException( 
+                throw new java.io.IOException(
                 "Bad Base64 input character '" + source[i] + "' in array position " + i);
-            }   // end else: 
+            }   // end else:
         }   // each input character
-                                   
+
         byte[] out = new byte[ outBuffPosn ];
-        System.arraycopy( outBuff, 0, out, 0, outBuffPosn ); 
+        System.arraycopy( outBuff, 0, out, 0, outBuffPosn );
         return out;
     }   // end decode
-    
-    
-	
-	
+
+
+
+
     /**
      * Decodes data from Base64 notation, automatically
      * detecting gzip-compressed data and decompressing it.
@@ -1213,8 +1213,8 @@ public class Base64
         return decode( s, NO_OPTIONS );
     }
 
-    
-    
+
+
     /**
      * Decodes data from Base64 notation, automatically
      * detecting gzip-compressed data and decompressing it.
@@ -1227,11 +1227,11 @@ public class Base64
      * @since 1.4
      */
     public static byte[] decode( String s, int options ) throws java.io.IOException {
-        
+
         if( s == null ){
             throw new NullPointerException( "Input string was null." );
         }   // end if
-        
+
         byte[] bytes;
         try {
             bytes = s.getBytes( PREFERRED_ENCODING );
@@ -1240,15 +1240,15 @@ public class Base64
             bytes = s.getBytes();
         }   // end catch
 		//</change>
-        
+
         // Decode
         bytes = decode( bytes, 0, bytes.length, options );
-        
+
         // Check to see if it's gzip-compressed
         // GZIP Magic Two-Byte Number: 0x8b1f (35615)
         boolean dontGunzip = (options & DONT_GUNZIP) != 0;
         if( (bytes != null) && (bytes.length >= 4) && (!dontGunzip) ) {
-            
+
             int head = ((int)bytes[0] & 0xff) | ((bytes[1] << 8) & 0xff00);
             if( java.util.zip.GZIPInputStream.GZIP_MAGIC == head )  {
                 java.io.ByteArrayInputStream  bais = null;
@@ -1282,14 +1282,14 @@ public class Base64
 
             }   // end if: gzipped
         }   // end if: bytes.length >= 2
-        
+
         return bytes;
     }   // end decode
-    
+
     /* ********  I N N E R   C L A S S   I N P U T S T R E A M  ******** */
-    
-    
-    
+
+
+
     /**
      * A {@link Base64.InputStream} will read data from another
      * <tt>java.io.InputStream</tt>, given in the constructor,
@@ -1299,7 +1299,7 @@ public class Base64
      * @since 1.3
      */
     public static class InputStream extends java.io.FilterInputStream {
-        
+
         private boolean encode;         // Encoding or decoding
         private int     position;       // Current position in the buffer
         private byte[]  buffer;         // Small buffer holding converted data
@@ -1309,8 +1309,8 @@ public class Base64
         private boolean breakLines;     // Break lines at less than 80 characters
         private int     options;        // Record options used to create the stream.
         private byte[]  decodabet;      // Local copies to avoid extra method calls
-        
-        
+
+
         /**
          * Constructs a {@link Base64.InputStream} in DECODE mode.
          *
@@ -1320,8 +1320,8 @@ public class Base64
         public InputStream( java.io.InputStream in ) {
             this( in, DECODE );
         }   // end constructor
-        
-        
+
+
         /**
          * Constructs a {@link Base64.InputStream} in
          * either ENCODE or DECODE mode.
@@ -1343,7 +1343,7 @@ public class Base64
          * @since 2.0
          */
         public InputStream( java.io.InputStream in, int options ) {
-            
+
             super( in );
             this.options      = options; // Record for later
             this.breakLines   = (options & DO_BREAK_LINES) > 0;
@@ -1354,7 +1354,7 @@ public class Base64
             this.lineLength   = 0;
             this.decodabet    = getDecodabet(options);
         }   // end constructor
-        
+
         /**
          * Reads enough of the input stream to convert
          * to/from Base64 and returns the next byte.
@@ -1363,7 +1363,7 @@ public class Base64
          * @since 1.3
          */
         public int read() throws java.io.IOException  {
-            
+
             // Do we need to get data?
             if( position < 0 ) {
                 if( encode ) {
@@ -1379,9 +1379,9 @@ public class Base64
                         } else {
                             break; // out of for loop
                         }   // end else: end of stream
-                            
+
                     }   // end for: each needed input byte
-                    
+
                     if( numBinaryBytes > 0 ) {
                         encode3to4( b3, 0, numBinaryBytes, buffer, 0, options );
                         position = 0;
@@ -1391,7 +1391,7 @@ public class Base64
                         return -1;  // Must be end of stream
                     }   // end else
                 }   // end if: encoding
-                
+
                 // Else decoding
                 else {
                     byte[] b4 = new byte[4];
@@ -1401,14 +1401,14 @@ public class Base64
                         int b = 0;
                         do{ b = in.read(); }
                         while( b >= 0 && decodabet[ b & 0x7f ] <= WHITE_SPACE_ENC );
-                        
+
                         if( b < 0 ) {
                             break; // Reads a -1 if end of stream
                         }   // end if: end of stream
-                        
+
                         b4[i] = (byte)b;
                     }   // end for: each needed input byte
-                    
+
                     if( i == 4 ) {
                         numSigBytes = decode4to3( b4, 0, buffer, 0, options );
                         position = 0;
@@ -1419,18 +1419,18 @@ public class Base64
                     else {
                         // Must have broken out from above.
                         throw new java.io.IOException( "Improperly padded Base64 input." );
-                    }   // end 
-                    
+                    }   // end
+
                 }   // end else: decode
             }   // end else: get data
-            
+
             // Got data?
             if( position >= 0 ) {
                 // End of relevant data?
                 if( /*!encode &&*/ position >= numSigBytes ){
                     return -1;
                 }   // end if: got data
-                
+
                 if( encode && breakLines && lineLength >= MAX_LINE_LENGTH ) {
                     lineLength = 0;
                     return '\n';
@@ -1439,7 +1439,7 @@ public class Base64
                     lineLength++;   // This isn't important when decoding
                                     // but throwing an extra "if" seems
                                     // just as wasteful.
-                    
+
                     int b = buffer[ position++ ];
 
                     if( position >= bufferLength ) {
@@ -1450,14 +1450,14 @@ public class Base64
                                      // intended to be unsigned.
                 }   // end else
             }   // end if: position >= 0
-            
+
             // Else error
             else {
                 throw new java.io.IOException( "Error in Base64 code reading stream." );
             }   // end else
         }   // end read
-        
-        
+
+
         /**
          * Calls {@link #read()} repeatedly until the end of stream
          * is reached or <var>len</var> bytes are read.
@@ -1470,13 +1470,13 @@ public class Base64
          * @return bytes read into array or -1 if end of stream is encountered.
          * @since 1.3
          */
-        public int read( byte[] dest, int off, int len ) 
+        public int read( byte[] dest, int off, int len )
         throws java.io.IOException {
             int i;
             int b;
             for( i = 0; i < len; i++ ) {
                 b = read();
-                
+
                 if( b >= 0 ) {
                     dest[off + i] = (byte) b;
                 }
@@ -1489,18 +1489,18 @@ public class Base64
             }   // end for: each byte read
             return i;
         }   // end read
-        
+
     }   // end inner class InputStream
-    
-    
-    
-    
-    
-    
+
+
+
+
+
+
     /* ********  I N N E R   C L A S S   O U T P U T S T R E A M  ******** */
-    
-    
-    
+
+
+
     /**
      * A {@link Base64.OutputStream} will write data to another
      * <tt>java.io.OutputStream</tt>, given in the constructor,
@@ -1510,7 +1510,7 @@ public class Base64
      * @since 1.3
      */
     public static class OutputStream extends java.io.FilterOutputStream {
-        
+
         private boolean encode;
         private int     position;
         private byte[]  buffer;
@@ -1521,7 +1521,7 @@ public class Base64
         private boolean suspendEncoding;
         private int     options;    // Record for later
         private byte[]  decodabet;  // Local copies to avoid extra method calls
-        
+
         /**
          * Constructs a {@link Base64.OutputStream} in ENCODE mode.
          *
@@ -1531,8 +1531,8 @@ public class Base64
         public OutputStream( java.io.OutputStream out ) {
             this( out, ENCODE );
         }   // end constructor
-        
-        
+
+
         /**
          * Constructs a {@link Base64.OutputStream} in
          * either ENCODE or DECODE mode.
@@ -1565,8 +1565,8 @@ public class Base64
             this.options      = options;
             this.decodabet    = getDecodabet(options);
         }   // end constructor
-        
-        
+
+
         /**
          * Writes the byte to the output stream after
          * converting to/from Base64 notation.
@@ -1579,19 +1579,19 @@ public class Base64
          * @param theByte the byte to write
          * @since 1.3
          */
-        public void write(int theByte) 
+        public void write(int theByte)
         throws java.io.IOException {
             // Encoding suspended?
             if( suspendEncoding ) {
                 this.out.write( theByte );
                 return;
             }   // end if: supsended
-            
+
             // Encode?
             if( encode ) {
                 buffer[ position++ ] = (byte)theByte;
                 if( position >= bufferLength ) { // Enough to encode.
-                
+
                     this.out.write( encode3to4( b4, buffer, bufferLength, options ) );
 
                     lineLength += 4;
@@ -1610,7 +1610,7 @@ public class Base64
                 if( decodabet[ theByte & 0x7f ] > WHITE_SPACE_ENC ) {
                     buffer[ position++ ] = (byte)theByte;
                     if( position >= bufferLength ) { // Enough to output.
-                    
+
                         int len = Base64.decode4to3( buffer, 0, b4, 0, options );
                         out.write( b4, 0, len );
                         position = 0;
@@ -1621,11 +1621,11 @@ public class Base64
                 }   // end else: not white space either
             }   // end else: decoding
         }   // end write
-        
-        
-        
+
+
+
         /**
-         * Calls {@link #write(int)} repeatedly until <var>len</var> 
+         * Calls {@link #write(int)} repeatedly until <var>len</var>
          * bytes are written.
          *
          * @param theBytes array from which to read bytes
@@ -1633,22 +1633,22 @@ public class Base64
          * @param len max number of bytes to read into array
          * @since 1.3
          */
-        public void write( byte[] theBytes, int off, int len ) 
+        public void write( byte[] theBytes, int off, int len )
         throws java.io.IOException {
             // Encoding suspended?
             if( suspendEncoding ) {
                 this.out.write( theBytes, off, len );
                 return;
             }   // end if: supsended
-            
+
             for( int i = 0; i < len; i++ ) {
                 write( theBytes[ off + i ] );
             }   // end for: each byte written
-            
+
         }   // end write
-        
-        
-        
+
+
+
         /**
          * Method added by PHIL. [Thanks, PHIL. -Rob]
          * This pads the buffer without closing the stream.
@@ -1667,9 +1667,9 @@ public class Base64
 
         }   // end flush
 
-        
-        /** 
-         * Flushes and closes (I think, in the superclass) the stream. 
+
+        /**
+         * Flushes and closes (I think, in the superclass) the stream.
          *
          * @since 1.3
          */
@@ -1680,13 +1680,13 @@ public class Base64
             // 2. Actually close the stream
             // Base class both flushes and closes.
             super.close();
-            
+
             buffer = null;
             out    = null;
         }   // end close
-        
-        
-        
+
+
+
         /**
          * Suspends encoding of the stream.
          * May be helpful if you need to embed a piece of
@@ -1699,8 +1699,8 @@ public class Base64
             flushBase64();
             this.suspendEncoding = true;
         }   // end suspendEncoding
-        
-        
+
+
         /**
          * Resumes encoding of the stream.
          * May be helpful if you need to embed a piece of
@@ -1711,10 +1711,10 @@ public class Base64
         public void resumeEncoding() {
             this.suspendEncoding = false;
         }   // end resumeEncoding
-        
-        
-        
+
+
+
     }   // end inner class OutputStream
-    
-    
+
+
 }   // end class Base64

--- a/src/net/nczonline/web/datauri/DataURI.java
+++ b/src/net/nczonline/web/datauri/DataURI.java
@@ -1,17 +1,17 @@
 /*
  * Copyright (c) 2009 Nicholas C. Zakas. All rights reserved.
  * http://www.nczonline.net/
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -31,21 +31,21 @@ import java.io.Writer;
 import java.net.URL;
 
 
-public class DataURI {    
+public class DataURI {
 
-    
+
     /**
      * @param args the command line arguments
      */
     public static void main(String[] args) {
-        
+
         //default settings
         boolean verbose = false;
         String charset = null;
         String outputFilename = null;
         Writer out = null;
         String mimeType = null;
-        
+
         //initialize command line parser
         CmdLineParser parser = new CmdLineParser();
         CmdLineParser.Option verboseOpt = parser.addBooleanOption('v', "verbose");
@@ -53,9 +53,9 @@ public class DataURI {
         CmdLineParser.Option helpOpt = parser.addBooleanOption('h', "help");
         CmdLineParser.Option charsetOpt = parser.addStringOption("charset");
         CmdLineParser.Option outputFilenameOpt = parser.addStringOption('o', "output");
-        
+
         try {
-            
+
             //parse the arguments
             parser.parse(args);
 
@@ -64,59 +64,59 @@ public class DataURI {
             if (help != null && help.booleanValue()) {
                 usage();
                 System.exit(0);
-            } 
-            
+            }
+
             //determine boolean options
             verbose = parser.getOptionValue(verboseOpt) != null;
-            
+
             //check for charset
             charset = (String) parser.getOptionValue(charsetOpt);
-            
+
             //check for MIME type
             mimeType = (String) parser.getOptionValue(mimeTypeOpt);
 
             //get the file arguments
             String[] fileArgs = parser.getRemainingArgs();
-            
+
             //need to have at least one file
             if (fileArgs.length == 0){
                 System.err.println("[ERROR] No files specified.");
                 System.exit(1);
             }
-            
+
             //only the first filename is used
-            String inputFilename = fileArgs[0];            
-                                  
+            String inputFilename = fileArgs[0];
+
             //get output filename
             outputFilename = (String) parser.getOptionValue(outputFilenameOpt);
-            
+
             if (outputFilename == null) {
                 if (verbose){
                     System.err.println("[INFO] No output file specified, defaulting to stdout.");
-                }                
-                
+                }
+
                 out = new OutputStreamWriter(System.out);
             } else {
                 if (verbose){
                     System.err.println("[INFO] Output file is '" + (new File(outputFilename)).getAbsolutePath() + "'");
                 }
                 out = new OutputStreamWriter(new FileOutputStream(outputFilename), "UTF-8");
-            }            
-            
+            }
+
             //set verbose option
             DataURIGenerator.setVerbose(verbose);
-            
+
             //determine if the filename is a local file or a URL
             if (inputFilename.startsWith("http://")){
                 DataURIGenerator.generate(new URL(inputFilename), out, mimeType);
             } else {
                 DataURIGenerator.generate(new File(inputFilename), out, mimeType);
-            }          
-            
+            }
+
         } catch (CmdLineParser.OptionException e) {
             usage();
-            System.exit(1);            
-        } catch (Exception e) { 
+            System.exit(1);
+        } catch (Exception e) {
             e.printStackTrace();
             System.exit(1);
         } finally {
@@ -126,11 +126,11 @@ public class DataURI {
                 } catch (IOException e) {
                     e.printStackTrace();
                 }
-            }            
+            }
         }
-        
+
     }
-    
+
     /**
      * Outputs help information to the console.
      */

--- a/src/net/nczonline/web/datauri/DataURIGenerator.java
+++ b/src/net/nczonline/web/datauri/DataURIGenerator.java
@@ -1,17 +1,17 @@
 /*
  * Copyright (c) 2009 Nicholas C. Zakas. All rights reserved.
  * http://www.nczonline.net/
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -20,7 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
- 
+
 package net.nczonline.web.datauri;
 
 import java.io.ByteArrayOutputStream;
@@ -38,96 +38,96 @@ import java.net.URLConnection;
  * @author Nicholas C. Zakas
  */
 public class DataURIGenerator {
- 
+
 
     private static HashMap binaryTypes = new HashMap();
     private static HashMap textTypes = new HashMap();
     private static boolean verbose = false;
- 
+
     //initialize file types and MIME types
-    static {        
+    static {
         binaryTypes.put("gif", "image/gif");
         binaryTypes.put("jpg", "image/jpeg");
         binaryTypes.put("png", "image/png");
-        binaryTypes.put("jpeg", "image/jpeg");   
-        
+        binaryTypes.put("jpeg", "image/jpeg");
+
         textTypes.put("htm", "text/html");
         textTypes.put("html", "text/html");
         textTypes.put("xml", "application/xml");
-        textTypes.put("xhtml", "application/xhtml+xml");  
+        textTypes.put("xhtml", "application/xhtml+xml");
         textTypes.put("js", "application/x-javascript");
         textTypes.put("css", "text/css");
         textTypes.put("txt", "text/plain");
-    }    
-    
+    }
+
     //--------------------------------------------------------------------------
     // Get/Set verbose flag
-    //--------------------------------------------------------------------------    
-    
+    //--------------------------------------------------------------------------
+
     public static boolean getVerbose(){
         return verbose;
     }
-    
+
     public static void setVerbose(boolean newVerbose){
         verbose = newVerbose;
     }
-    
+
     //--------------------------------------------------------------------------
     // Generate data URIs from a file
     //--------------------------------------------------------------------------
-    
+
     /**
      * Generates a data URI from a file, outputting it to the given writer. The
      * MIME type is determined from examining the filename.
      * @param file The file from which to generate the data URI.
      * @param out Where to output the data URI.
      * @throws java.io.IOException
-     */ 
+     */
     public static void generate(File file, Writer out) throws IOException {
-        generate(file, out, null);        
+        generate(file, out, null);
     }
-    
+
     /**
      * Generates a data URI from a file, outputting it to the given writer.
      * @param file The file from which to generate the data URI.
      * @param out Where to output the data URI.
      * @param mimeType The MIME type to use for the data URI.
      * @throws java.io.IOException
-     */    
+     */
     public static void generate(File file, Writer out, String mimeType) throws IOException {
-        generateDataURI(file, out, mimeType);        
-    }   
-  
+        generateDataURI(file, out, mimeType);
+    }
+
     //--------------------------------------------------------------------------
     // Generate data URIs from a URL
     //--------------------------------------------------------------------------
-    
+
     /**
      * Generates a data URI from a file, outputting it to the given writer. The
      * MIME type is determined from examining the filename.
      * @param file The file from which to generate the data URI.
      * @param out Where to output the data URI.
      * @throws java.io.IOException
-     */ 
+     */
     public static void generate(URL url, Writer out) throws IOException {
-        generate(url, out, null);        
+        generate(url, out, null);
     }
-    
+
     /**
      * Generates a data URI from a URL, outputting it to the given writer.
      * @param url The URL form which to generate the data URI.
      * @param out Where to output the data URI.
      * @param mimeType The MIME type to use for the data URI.
      * @throws java.io.IOException
-     */    
+     */
     public static void generate(URL url, Writer out, String mimeType) throws IOException {
-        generateDataURI(url, out, mimeType);        
+        generateDataURI(url, out, mimeType);
     }
-    
+
     //--------------------------------------------------------------------------
     // Helper methods
-    //--------------------------------------------------------------------------    
-   
+    //--------------------------------------------------------------------------
+
     /**
      * Generates a data URI from the specified file and outputs to the given writer.
      * @param file The file to from which to create a data URI.
@@ -137,18 +137,18 @@ public class DataURIGenerator {
      * @throws java.io.IOException
      */
     private static void generateDataURI(File file, Writer out, String mimeType) throws IOException{
-        
+
         //read the bytes from the file
         InputStream in = new FileInputStream(file);
         byte[] bytes = new byte[(int) file.length()];
         in.read(bytes);
-        in.close();  
-        
+        in.close();
+
         //verify MIME type and charset
-        mimeType = getMimeType(file.getName(), mimeType);      
-        
+        mimeType = getMimeType(file.getName(), mimeType);
+
         //actually write
-        generateDataURI(bytes, out, mimeType);        
+        generateDataURI(bytes, out, mimeType);
     }
 
     /**
@@ -159,39 +159,39 @@ public class DataURIGenerator {
      * @throws java.io.IOException
      */
     private static void generateDataURI(URL url, Writer out, String mimeType) throws IOException{
-        
+
         //get information about the URL
         URLConnection conn = url.openConnection();
-        
+
         //if no MIME type has been specified, get from the connection
-        if (mimeType == null){            
+        if (mimeType == null){
             mimeType = getMimeType(url.getFile(), conn.getContentType());
             if (verbose){
                 System.err.println("[INFO] No MIME type provided, using detected type of '" + mimeType + "'.");
-            }            
+            }
         }
-        
+
         //sometimes charset is in the MIME type
-        if (mimeType.indexOf("; charset=") > -1){                        
+        if (mimeType.indexOf("; charset=") > -1){
             mimeType = mimeType.replace(" ", ""); //remove the space
         } else {
             mimeType = getMimeTypeWithCharset(mimeType);
         }
-        
+
         //read the bytes from the URL
-        InputStream in = conn.getInputStream();       
+        InputStream in = conn.getInputStream();
         ByteArrayOutputStream byteStream = new ByteArrayOutputStream();
         int c;
-        
+
         while((c = in.read()) != -1){
             byteStream.write(c);
         }
-        
+
         byteStream.flush();
-        in.close();        
-        
+        in.close();
+
         //actually write
-        generateDataURI(byteStream.toByteArray(), out, mimeType);        
+        generateDataURI(byteStream.toByteArray(), out, mimeType);
     }
 
     /**
@@ -203,22 +203,22 @@ public class DataURIGenerator {
      * @throws java.io.IOException
      */
     private static void generateDataURI(byte[] bytes, Writer out, String mimeType) throws IOException {
-        
+
         //create the output
-        StringBuffer buffer = new StringBuffer();        
-        buffer.append("data:");        
-        
-        //add MIME type        
+        StringBuffer buffer = new StringBuffer();
+        buffer.append("data:");
+
+        //add MIME type
         buffer.append(mimeType);
-        
+
         //output base64-encoding
         buffer.append(";base64,");
         buffer.append(new String(Base64.encodeBytes(bytes)));
-        
+
         //output to writer
-        out.write(buffer.toString());        
-    }    
-    
+        out.write(buffer.toString());
+    }
+
     /**
      * Determines if the given filename represents an image file.
      * @param filename The filename to check.
@@ -228,9 +228,9 @@ public class DataURIGenerator {
         String fileType = getFileType(filename);
         return binaryTypes.containsKey(fileType) && binaryTypes.get(fileType).toString().startsWith("image");
     }
-    
+
     /**
-     * Retrieves the extension for the filename. 
+     * Retrieves the extension for the filename.
      * @param filename The filename to get the extension from.
      * @return All characters after the final "." in the filename.
      */
@@ -241,7 +241,7 @@ public class DataURIGenerator {
         if (idx >= 0 && idx < filename.length() - 1) {
             type = filename.substring(idx + 1);
         }
-        
+
         return type;
     }
 
@@ -256,40 +256,40 @@ public class DataURIGenerator {
      */
     private static String getMimeType(String filename, String mimeType) throws IOException {
         if (mimeType == null){
-            
+
             String type = getFileType(filename);
 
             //if it's an image type, don't use a charset
-            if (binaryTypes.containsKey(type)){    
-                mimeType = (String) binaryTypes.get(type);        
+            if (binaryTypes.containsKey(type)){
+                mimeType = (String) binaryTypes.get(type);
             } else if (textTypes.containsKey(type)){
-                mimeType = (String) textTypes.get(type) + ";charset=UTF-8";    
+                mimeType = (String) textTypes.get(type) + ";charset=UTF-8";
             } else {
-                throw new IOException("No MIME type provided and MIME type couldn't be automatically determined.");                
+                throw new IOException("No MIME type provided and MIME type couldn't be automatically determined.");
             }
 
             if (verbose){
                 System.err.println("[INFO] No MIME type provided, defaulting to '" + mimeType + "'.");
-            }      
+            }
         }
-        
-        return mimeType;      
+
+        return mimeType;
     }
-    
-    private static String getMimeTypeWithCharset(String mimeType){           
+
+    private static String getMimeTypeWithCharset(String mimeType){
 
         if (binaryTypes.containsValue(mimeType)){
             if (verbose){
                 System.err.println("[INFO] Image file detected, skipping charset.");
-            }             
+            }
             return mimeType;
         } else {
             if (verbose){
                 System.err.println("[INFO] Using charset 'UTF-8'.");
-            }   
+            }
             return mimeType + ";charset=UTF-8";
         }
 
     }
-            
+
 }

--- a/tests/net/nczonline/web/cssembed/CSSURLEmbedderTest.java
+++ b/tests/net/nczonline/web/cssembed/CSSURLEmbedderTest.java
@@ -25,13 +25,13 @@ import static org.junit.Assert.*;
  * @author Nicholas C. Zakas
  */
 public class CSSURLEmbedderTest {
-    
+
     private static String folderDataURI = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACIAAAAbCAMAAAAu7K2VAAAABGdBTUEAAK/INwWK6QAAABl0RVh0U29mdHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAAAwUExURWxsbNbW1v/rhf/ge//3kf/Ub9/f3/b29oeHh/7LZv/0juazTktLS8WSLf//mf/////BPrAAAAB4SURBVHja3NLdCoAgDIbhqbXZz2f3f7eZWUpMO67nQEReBqK0vaLPJohYegnSYqSdYAtRGvUYVpJhPpx7z2piLSqsJQ73oY1ztGREuEwBpCUTwpAt7cRmncRlnWTMoCdcXxmrdiMxngpvtDcSNkX9AvTnv9uyCzAAgzAw+dNAwOQAAAAASUVORK5CYII=";
     private CSSURLEmbedder embedder;
-    
+
     public CSSURLEmbedderTest() {
     }
-    
+
     @Before
     public void setUp() {
 
@@ -41,101 +41,101 @@ public class CSSURLEmbedderTest {
     public void tearDown() {
         embedder = null;
     }
-    
+
     @Test
     public void testAbsoluteLocalFile() throws IOException {
         String filename = CSSURLEmbedderTest.class.getResource("folder.png").getPath().replace("%20", " ");
         String code = "background: url(folder.png);";
-        
+
         StringWriter writer = new StringWriter();
         embedder = new CSSURLEmbedder(new StringReader(code), true);
         embedder.embedImages(writer, filename.substring(0, filename.lastIndexOf("/")+1));
-        
+
         String result = writer.toString();
         assertEquals("background: url(" + folderDataURI + ");", result);
     }
-    
+
     @Test
     public void testAbsoluteLocalFileWithMhtml() throws IOException {
         String filename = CSSURLEmbedderTest.class.getResource("folder.png").getPath().replace("%20", " ");
         String code = "background: url(folder.png);";
         String mhtmlUrl = "http://www.example.com/dir/";
-        
+
         StringWriter writer = new StringWriter();
         embedder = new CSSURLEmbedder(new StringReader(code), CSSURLEmbedder.MHTML_OPTION, true);
         embedder.setMHTMLRoot(mhtmlUrl);
         embedder.setFilename("styles_ie.css");
         embedder.embedImages(writer, filename.substring(0, filename.lastIndexOf("/")+1));
-        
+
         String result = writer.toString();
-        assertEquals("/*\nContent-Type: multipart/related; boundary=\"" + CSSURLEmbedder.MHTML_SEPARATOR + 
+        assertEquals("/*\nContent-Type: multipart/related; boundary=\"" + CSSURLEmbedder.MHTML_SEPARATOR +
                 "\"\n\n--" + CSSURLEmbedder.MHTML_SEPARATOR + "\nContent-Location:folder.png\n" +
                 "Content-Transfer-Encoding:base64\n\n" + folderDataURI.substring(folderDataURI.indexOf(",")+1) +
                 "\n\n--" + CSSURLEmbedder.MHTML_SEPARATOR + "--\n" +
                 "*/\nbackground: url(mhtml:" + mhtmlUrl + "styles_ie.css!folder.png);", result);
     }
-    
+
     @Test
     public void testAbsoluteLocalFileMultipleOneLine() throws IOException {
         String filename = CSSURLEmbedderTest.class.getResource("folder.png").getPath().replace("%20", " ");
         String code = "background: url(folder.png); background: url(folder.png);";
-        
+
         StringWriter writer = new StringWriter();
         embedder = new CSSURLEmbedder(new StringReader(code), true);
         embedder.embedImages(writer, filename.substring(0, filename.lastIndexOf("/")+1));
-        
+
         String result = writer.toString();
         assertEquals("background: url(" + folderDataURI + "); background: url(" + folderDataURI + ");", result);
     }
-    
+
     @Test
     public void testAbsoluteLocalFileWithDoubleQuotes() throws IOException {
         String filename = CSSURLEmbedderTest.class.getResource("folder.png").getPath().replace("%20", " ");
         String code = "background: url(\"folder.png\");";
-        
+
         StringWriter writer = new StringWriter();
         embedder = new CSSURLEmbedder(new StringReader(code), true);
         embedder.embedImages(writer, filename.substring(0, filename.lastIndexOf("/")+1));
-        
+
         String result = writer.toString();
         assertEquals("background: url(" + folderDataURI + ");", result);
     }
-    
+
     @Test
     public void testAbsoluteLocalFileWithSingleQuotes() throws IOException {
         String filename = CSSURLEmbedderTest.class.getResource("folder.png").getPath().replace("%20", " ");
         String code = "background: url('folder.png');";
-        
+
         StringWriter writer = new StringWriter();
         embedder = new CSSURLEmbedder(new StringReader(code), true);
         embedder.embedImages(writer, filename.substring(0, filename.lastIndexOf("/")+1));
-        
+
         String result = writer.toString();
         assertEquals("background: url(" + folderDataURI + ");", result);
-    }     
-    
+    }
+
     @Test (expected=IOException.class)
     public void testAbsoluteLocalFileWithMissingFile() throws IOException {
         String filename = CSSURLEmbedderTest.class.getResource("folder.png").getPath().replace("%20", " ");
         String code = "background: url(fooga.png);";
-        
+
         StringWriter writer = new StringWriter();
         embedder = new CSSURLEmbedder(new StringReader(code),true);
         embedder.embedImages(writer, filename.substring(0, filename.lastIndexOf("/")+1));
-        
+
         String result = writer.toString();
         assertEquals(code, result);
     }
-    
+
     @Test
     public void testAbsoluteLocalFileWithMissingFilesEnabled() throws IOException {
         String filename = CSSURLEmbedderTest.class.getResource("folder.png").getPath().replace("%20", " ");
         String code = "background: url(fooga.png);";
-        
+
         StringWriter writer = new StringWriter();
         embedder = new CSSURLEmbedder(new StringReader(code), CSSURLEmbedder.SKIP_MISSING_OPTION, true);
         embedder.embedImages(writer, filename.substring(0, filename.lastIndexOf("/")+1));
-        
+
         String result = writer.toString();
         assertEquals(code, result);
     }
@@ -146,72 +146,72 @@ public class CSSURLEmbedderTest {
     public void testAbsoluteLocalFileUnderMaxLength() throws IOException {
         String filename = CSSURLEmbedderTest.class.getResource("folder.png").getPath().replace("%20", " ");
         String code = "background: url(folder.png);";
-        
+
         StringWriter writer = new StringWriter();
         embedder = new CSSURLEmbedder(new StringReader(code), CSSURLEmbedder.DATAURI_OPTION, true, 1000);
         embedder.embedImages(writer, filename.substring(0, filename.lastIndexOf("/")+1));
-        
+
         String result = writer.toString();
         assertEquals("background: url(" + folderDataURI + ");", result);
     }
-    
+
     @Test
     public void testAbsoluteLocalFileOverMaxLength() throws IOException {
         String filename = CSSURLEmbedderTest.class.getResource("folder.png").getPath().replace("%20", " ");
         String code = "background: url(folder.png);";
-        
+
         StringWriter writer = new StringWriter();
         embedder = new CSSURLEmbedder(new StringReader(code), CSSURLEmbedder.DATAURI_OPTION, true, 200);
         embedder.embedImages(writer, filename.substring(0, filename.lastIndexOf("/")+1));
-        
+
         String result = writer.toString();
         assertEquals(code, result);
     }
-    
+
     @Test
     public void testAbsoluteLocalFileUnderMaxImageSize() throws IOException {
         String filename = CSSURLEmbedderTest.class.getResource("folder.png").getPath().replace("%20", " ");
         String code = "background: url(folder.png);";
-        
+
         StringWriter writer = new StringWriter();
         embedder = new CSSURLEmbedder(new StringReader(code), CSSURLEmbedder.DATAURI_OPTION, true, 0, 300);
         embedder.embedImages(writer, filename.substring(0, filename.lastIndexOf("/")+1));
-        
+
         String result = writer.toString();
         assertEquals("background: url(" + folderDataURI + ");", result);
     }
-    
+
     @Test
     public void testAbsoluteLocalFileOverMaxImageSize() throws IOException {
         String filename = CSSURLEmbedderTest.class.getResource("folder.png").getPath().replace("%20", " ");
         String code = "background: url(folder.png);";
-        
+
         StringWriter writer = new StringWriter();
         embedder = new CSSURLEmbedder(new StringReader(code), CSSURLEmbedder.DATAURI_OPTION, true, 0, 200);
         embedder.embedImages(writer, filename.substring(0, filename.lastIndexOf("/")+1));
-        
+
         String result = writer.toString();
         assertEquals(code, result);
     }
-    
+
     @Test
     public void testReadFromAndWriteToSameFile() throws IOException {
         String filename = CSSURLEmbedderTest.class.getResource("samefiletest.css").getPath().replace("%20", " ");
         File file = new File(filename);
         Reader in = new InputStreamReader(new FileInputStream(file));
-        
+
         embedder = new CSSURLEmbedder(in, true);
         in.close();
-        
-        Writer writer = new OutputStreamWriter(new FileOutputStream(file));        
+
+        Writer writer = new OutputStreamWriter(new FileOutputStream(file));
         embedder.embedImages(writer, filename.substring(0, filename.lastIndexOf("/")+1));
         writer.close();
-        
+
         in = new InputStreamReader(new FileInputStream(file));
         char[] chars = new char[(int)file.length()];
         in.read(chars, 0, (int)file.length());
         in.close();
-        
+
         String result = new String(chars);
         assertEquals("background: url(" + folderDataURI + ");", result);
     }
@@ -237,7 +237,7 @@ public class CSSURLEmbedderTest {
     public void testRemoteUrlWithQueryString() throws IOException {
     	final String expectedUrl = "http://some-http-server.com/image/with/query/parameters/image.png?a=b&c=d";
     	String code = "background : url(/image/with/query/parameters/image.png?a=b&c=d)";
-    	
+
     	StringWriter writer = new StringWriter();
         embedder = new CSSURLEmbedder(new StringReader(code), CSSURLEmbedder.DATAURI_OPTION, true, 0, 200) {
         	/*
@@ -252,11 +252,11 @@ public class CSSURLEmbedderTest {
 			}
         };
         embedder.embedImages(writer, "http://some-http-server.com/");
-        
+
         String result = writer.toString();
         assertEquals("background : url(data:image/gif;base64,AAAABBBBCCCCDDDD)", result);
     }
-    
+
     @Test
     public void testImageDetection() {
     	String tests[] = {
@@ -268,7 +268,7 @@ public class CSSURLEmbedderTest {
     	boolean expectedImage[] = {
     		true, true, true, false
     	};
-    	
+
     	for(int i=0; i<tests.length; i++) {
     		if(expectedImage[i]) {
     			assertTrue("Expected " + tests[i] + " to resolve to an image", CSSURLEmbedder.isImage(tests[i]));
@@ -277,18 +277,18 @@ public class CSSURLEmbedderTest {
     			assertFalse("Did NOT expect " + tests[i] + " to resolve as an image", CSSURLEmbedder.isImage(tests[i]));
     		}
     	}
-    	
+
     }
-    
+
     @Test
     public void testRegularUrlWithSkipComment() throws IOException {
         String filename = CSSURLEmbedderTest.class.getResource("folder.png").getPath().replace("%20", " ");
         String code = "background: url(folder.png);  /* CssEmbed: SKIP */";
-        
+
         StringWriter writer = new StringWriter();
         embedder = new CSSURLEmbedder(new StringReader(code), true);
         embedder.embedImages(writer, filename.substring(0, filename.lastIndexOf("/")+1));
-        
+
         String result = writer.toString();
 		//assert that nothing changed
         assertEquals(code, result);

--- a/tests/net/nczonline/web/cssembed/CSSURLEmbedderTest.java
+++ b/tests/net/nczonline/web/cssembed/CSSURLEmbedderTest.java
@@ -69,10 +69,35 @@ public class CSSURLEmbedderTest {
 
         String result = writer.toString();
         assertEquals("/*\nContent-Type: multipart/related; boundary=\"" + CSSURLEmbedder.MHTML_SEPARATOR +
-                "\"\n\n--" + CSSURLEmbedder.MHTML_SEPARATOR + "\nContent-Location:folder.png\n" +
+                "\"\n\n\n--" + CSSURLEmbedder.MHTML_SEPARATOR + "\nContent-Location:folder.png\n" +
                 "Content-Transfer-Encoding:base64\n\n" + folderDataURI.substring(folderDataURI.indexOf(",")+1) +
                 "\n\n--" + CSSURLEmbedder.MHTML_SEPARATOR + "--\n" +
                 "*/\nbackground: url(mhtml:" + mhtmlUrl + "styles_ie.css!folder.png);", result);
+    }
+
+    @Test
+    public void testAbsoluteLocalFileWithMhtmlFile() throws IOException {
+        String filename = CSSURLEmbedderTest.class.getResource("folder.png").getPath().replace("%20", " ");
+        String code = "background: url(folder.png);";
+        String mhtmlUrl = "http://www.example.com/dir/";
+
+        StringWriter cssWriter = new StringWriter();
+        StringWriter mhtmlWriter = new StringWriter();
+        int options = CSSURLEmbedder.MHTML_OPTION;
+        options = options | CSSURLEmbedder.MHTML_FILE_OPTION;
+        embedder = new CSSURLEmbedder(new StringReader(code), options, true);
+        embedder.setMHTMLRoot(mhtmlUrl);
+        embedder.setFilename("styles_ie.mht");
+        embedder.embedImages(cssWriter, mhtmlWriter, filename.substring(0, filename.lastIndexOf("/")+1));
+
+        String mhtmlResult = mhtmlWriter.toString();
+        assertEquals("Content-Type: multipart/related; boundary=\"" + CSSURLEmbedder.MHTML_SEPARATOR +
+                "\"\n\n\n--" + CSSURLEmbedder.MHTML_SEPARATOR + "\nContent-Location:folder.png\n" +
+                "Content-Transfer-Encoding:base64\n\n" + folderDataURI.substring(folderDataURI.indexOf(",")+1) +
+                "\n\n--" + CSSURLEmbedder.MHTML_SEPARATOR + "--\n", mhtmlResult);
+
+        String cssResult = cssWriter.toString();
+        assertEquals("background: url(mhtml:" + mhtmlUrl + "styles_ie.mht!folder.png);", cssResult);
     }
 
     @Test


### PR DESCRIPTION
Nicholas, thanks for cssembed and all the great blog posts related to data URIs and MHTML.

This pull request attempts to resolve issues #17 & issue #34. It is my first pull request on GitHub.

I experienced the behavior described in #17. The unexpected behavior occurred on IE6/WinXP fully patched and IE7/Vista fully patched. The fix was to add one additional newline. Verified on both environments.

I added a new 'mhtmlfile' option to split the output between a CSS file and an MHTML file. This helps to address recent changes in Internet Explorer -- noted in issue #34 -- that require different MIME types for each of those file types.

This request does not include Ant Task support or additional unit tests. Ant Task support is complicated by the current usage of resource collection and mapper. Unit tests are simply left for another day.
